### PR TITLE
✨ feat: 팀 카드 컴포넌트를 추가하고 홈 페이지에 통합

### DIFF
--- a/app/common/pages/home-page.tsx
+++ b/app/common/pages/home-page.tsx
@@ -4,6 +4,10 @@ import { ProductCard } from "~/features/products/components/product-card";
 import { PostCard } from "~/features/community/components/post-card";
 import { IdeaCard } from "~/features/ideas/components/idea-card";
 import { JobCard } from "~/features/jobs/components/job-card";
+import { Card, CardHeader, CardTitle, CardFooter } from "../components/ui/card";
+import { Badge } from "../components/ui/badge";
+import { Avatar, AvatarFallback, AvatarImage } from "../components/ui/avatar";
+import { TeamCard } from "~/features/teams/components/team-card";
 
 export const meta: MetaFunction = () => {
   return [
@@ -28,7 +32,7 @@ export default function HomePage() {
           </Button>
         </div>
 
-        {Array.from({ length: 10 }, (_, index) => (
+        {Array.from({ length: 11 }, (_, index) => (
           <ProductCard
             key={index}
             id={`product-${index}`}
@@ -52,7 +56,7 @@ export default function HomePage() {
             <Link to="/community">Explore all discussions &rarr;</Link>
           </Button>
         </div>
-        {Array.from({ length: 10 }, (_, index) => (
+        {Array.from({ length: 11 }, (_, index) => (
           <PostCard
             key={index}
             id={`post-${index}`}
@@ -76,7 +80,7 @@ export default function HomePage() {
             <Link to="/ideas">Explore all ideas &rarr;</Link>
           </Button>
         </div>
-        {Array.from({ length: 10 }, (_, index) => (
+        {Array.from({ length: 11 }, (_, index) => (
           <IdeaCard
             key={index}
             id={`idea-${index}`}
@@ -111,6 +115,33 @@ export default function HomePage() {
             type="Full-time"
             positionLocation="Remote"
             salary="$100,000 - $120,000"
+          />
+        ))}
+      </div>
+      <div className="grid grid-cols-3 gap-4">
+        <div>
+          <h2 className="text-5xl font-bold leading-tight tracking-tighter">
+            Find a team mate
+          </h2>
+          <p className="text-xl font-light text-foreground">
+            Join a team looking for a new member.
+          </p>
+          <Button variant="link" asChild className="text-lg p-0">
+            <Link to="/teams">Explore all teams &rarr;</Link>
+          </Button>
+        </div>
+        {Array.from({ length: 11 }, (_, index) => (
+          <TeamCard
+            key={index}
+            id={`team-${index}`}
+            leaderUsername="lynn"
+            leaderAvatarUrl="https://github.com/inthetiger.png"
+            positions={[
+              "React Developer",
+              "Backend Developer",
+              "Product Manager",
+            ]}
+            projectDescription="a new social media platform"
           />
         ))}
       </div>

--- a/app/features/teams/components/team-card.tsx
+++ b/app/features/teams/components/team-card.tsx
@@ -1,0 +1,62 @@
+import { Link } from "react-router";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardFooter,
+} from "~/common/components/ui/card";
+import { Button } from "~/common/components/ui/button";
+import { Badge } from "~/common/components/ui/badge";
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+} from "~/common/components/ui/avatar";
+
+interface TeamCardProps {
+  id: string;
+  leaderUsername: string;
+  leaderAvatarUrl: string;
+  positions: string[];
+  projectDescription: string;
+}
+
+export function TeamCard({
+  id,
+  leaderUsername,
+  leaderAvatarUrl,
+  positions,
+  projectDescription,
+}: TeamCardProps) {
+  return (
+    <Link to={`/teams/${id}`}>
+      <Card className="bg-transparent hover:bg-card/50 transition-colors">
+        <CardHeader className="flex flex-row items-center">
+          <CardTitle className="text-base leading-loose">
+            <Badge
+              variant="secondary"
+              className="inline-flex shadow-sm items-center text-base"
+            >
+              <span>@{leaderUsername}</span>
+              <Avatar className="size-5">
+                <AvatarFallback>N</AvatarFallback>
+                <AvatarImage src={leaderAvatarUrl} />
+              </Avatar>
+            </Badge>
+            <span> is looking for </span>
+            {positions.map((position) => (
+              <Badge key={position} className="text-base">
+                {position}
+              </Badge>
+            ))}
+            <span> to build </span>
+            <span>{projectDescription}</span>
+          </CardTitle>
+        </CardHeader>
+        <CardFooter className="justify-end">
+          <Button variant="link">Join team &rarr;</Button>
+        </CardFooter>
+      </Card>
+    </Link>
+  );
+}


### PR DESCRIPTION
## Pull Request Description

### Title
✨ feat: 팀 카드 컴포넌트를 추가하고 홈 페이지에 통합

### Description
이 PR에서는 팀 카드 컴포넌트를 새로 추가하여 팀 정보를 효과적으로 표시합니다. 홈 페이지에 팀 카드 섹션을 통합하여 사용자가 팀을 쉽게 찾고 참여할 수 있도록 개선하였습니다. 각 팀 카드에는 팀 리더의 정보, 모집 중인 포지션, 그리고 프로젝트 설명이 포함되어 있어 사용자에게 유용한 정보를 제공합니다. 또한, 홈 페이지의 전반적인 레이아웃을 개선하여 사용자 경험을 향상시키는 데 기여합니다.

### Changes Made
- 팀 카드 컴포넌트 추가
- 홈 페이지에 팀 카드 섹션 통합
- 사용자 경험을 고려한 레이아웃 개선