### PR TITLE
refactor: 🧹 제품 페이지를 리다이렉트로 변경

### DIFF
--- a/app/common/pages/home-page.tsx
+++ b/app/common/pages/home-page.tsx
@@ -1,13 +1,10 @@
 import { Link, type MetaFunction } from "react-router";
-import { Button } from "../components/ui/button";
-import { ProductCard } from "~/features/products/components/product-card";
 import { PostCard } from "~/features/community/components/post-card";
 import { IdeaCard } from "~/features/ideas/components/idea-card";
 import { JobCard } from "~/features/jobs/components/job-card";
-import { Card, CardHeader, CardTitle, CardFooter } from "../components/ui/card";
-import { Badge } from "../components/ui/badge";
-import { Avatar, AvatarFallback, AvatarImage } from "../components/ui/avatar";
+import { ProductCard } from "~/features/products/components/product-card";
 import { TeamCard } from "~/features/teams/components/team-card";
+import { Button } from "../components/ui/button";
 
 export const meta: MetaFunction = () => {
   return [

--- a/app/features/products/pages/products-page.tsx
+++ b/app/features/products/pages/products-page.tsx
@@ -1,37 +1,5 @@
-import { Link } from "react-router";
-import type { MetaFunction } from "react-router";
-import { ProductCard } from "../components/product-card";
-import { Button } from "~/common/components/ui/button";
+import { redirect } from "react-router";
 
-export const meta: MetaFunction = () => {
-  return [
-    { title: "Products | wemake" },
-    { name: "description", content: "Explore all products on wemake" },
-  ];
-};
-
-export default function ProductsPage() {
-  return (
-    <div className="container py-10 space-y-6">
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-4xl font-bold">Products</h1>
-          <p className="text-xl text-muted-foreground">
-            Discover amazing products built by our community
-          </p>
-        </div>
-        <div className="space-x-4">
-          <Button asChild variant="outline">
-            <Link to="/products/submit">Submit Product</Link>
-          </Button>
-          <Button asChild>
-            <Link to="/products/promote">Promote Product</Link>
-          </Button>
-        </div>
-      </div>
-      <div className="grid grid-cols-3 gap-4">
-        {/* 실제 구현시 데이터를 로드하여 표시 */}
-      </div>
-    </div>
-  );
+export function loader() {
+  return redirect("/products/leaderboards");
 }


### PR DESCRIPTION
- 제품 페이지 컴포넌트와 메타 정보를 제거하고 /products/leaderboards 경로로 리다이렉트하도록 변경  
- 제품 페이지 역할 단순화 및 사용자 경험 개선  
- 홈 페이지에서 import 순서 정리로 코드 가독성 향상