### PR TITLE
✨ feat: 페이지별 메타 타이틀 동적 생성 추가

### DIFF
--- a/app/features/products/pages/daily-leaderboards-page.tsx
+++ b/app/features/products/pages/daily-leaderboards-page.tsx
@@ -1,16 +1,32 @@
 import { DateTime } from "luxon";
-import type { Route } from "./+types/daily-leaderboards-page";
 import { data, isRouteErrorResponse, Link } from "react-router";
 import { z } from "zod";
 import { Hero } from "~/common/components/hero";
-import { ProductCard } from "../components/product-card";
-import { Button } from "~/common/components/ui/button";
 import ProductPagination from "~/common/components/pagination";
+import { Button } from "~/common/components/ui/button";
+import { ProductCard } from "../components/product-card";
+import type { Route } from "./+types/daily-leaderboards-page";
 const paramsSchema = z.object({
   year: z.coerce.number(),
   month: z.coerce.number(),
   day: z.coerce.number(),
 });
+
+export const meta: Route.MetaFunction = ({ params }) => {
+  const date = DateTime.fromObject({
+    year: Number(params.year),
+    month: Number(params.month),
+    day: Number(params.day),
+  });
+
+  return [
+    {
+      title: `The best products of ${date.toLocaleString(
+        DateTime.DATE_MED
+      )} | wemake`,
+    },
+  ];
+};
 
 export const loader = ({ params }: Route.LoaderArgs) => {
   const { success, data: parsedData } = paramsSchema.safeParse(params);

--- a/app/features/products/pages/monthly-leaderboards-page.tsx
+++ b/app/features/products/pages/monthly-leaderboards-page.tsx
@@ -12,6 +12,22 @@ const paramsSchema = z.object({
   month: z.coerce.number(),
 });
 
+export const meta: Route.MetaFunction = ({ params }) => {
+  const date = DateTime.fromObject({
+    year: Number(params.year),
+    month: Number(params.month),
+  });
+
+  return [
+    {
+      title: `Best of ${date.startOf("month").toLocaleString({
+        year: "2-digit",
+        month: "long",
+      })} | wemake`,
+    },
+  ];
+};
+
 export const loader = ({ params }: Route.LoaderArgs) => {
   const { success, data: parsedData } = paramsSchema.safeParse(params);
 

--- a/app/features/products/pages/weekly-leaderboards-page.tsx
+++ b/app/features/products/pages/weekly-leaderboards-page.tsx
@@ -12,6 +12,23 @@ const paramsSchema = z.object({
   week: z.coerce.number(),
 });
 
+export const meta: Route.MetaFunction = ({ params }) => {
+  const date = DateTime.fromObject({
+    weekYear: Number(params.year),
+    weekNumber: Number(params.week),
+  });
+
+  return [
+    {
+      title: `Best of week ${date
+        .startOf("week")
+        .toLocaleString(DateTime.DATE_SHORT)} - ${date
+        .endOf("week")
+        .toLocaleString(DateTime.DATE_SHORT)} | wemake`,
+    },
+  ];
+};
+
 export const loader = ({ params }: Route.LoaderArgs) => {
   const { success, data: parsedData } = paramsSchema.safeParse(params);
 

--- a/app/features/products/pages/yearly-leaderboards-page.tsx
+++ b/app/features/products/pages/yearly-leaderboards-page.tsx
@@ -11,6 +11,20 @@ const paramsSchema = z.object({
   year: z.coerce.number(),
 });
 
+export const meta: Route.MetaFunction = ({ params }) => {
+  const date = DateTime.fromObject({
+    year: Number(params.year),
+  });
+
+  return [
+    {
+      title: `Best of ${date.startOf("year").toLocaleString({
+        year: "numeric",
+      })} | wemake`,
+    },
+  ];
+};
+
 export const loader = ({ params }: Route.LoaderArgs) => {
   const { success, data: parsedData } = paramsSchema.safeParse(params);
 


### PR DESCRIPTION
- 각 리더보드 페이지(일간, 주간, 월간, 연간)에 날짜 기반 메타 타이틀을 동적으로 생성하는 meta 함수 추가  
- SEO 최적화 및 사용자 경험 향상을 위해 각 페이지 타이틀에 해당 기간 정보 포함