### PR TITLE
✨ feat: 회원가입 및 인증 페이지 추가하고 레이아웃 개선

### DIFF
--- a/app/features/auth/layouts/auth-layout.tsx
+++ b/app/features/auth/layouts/auth-layout.tsx
@@ -1,0 +1,10 @@
+import { Outlet } from "react-router";
+
+export default function AuthLayout() {
+  return (
+    <div className="grid grid-cols-2 h-screen">
+      <div className="bg-gradient-to-br from-primary via-black to-primary/50" />
+      <Outlet />
+    </div>
+  );
+}

--- a/app/features/auth/pages/join-page.tsx
+++ b/app/features/auth/pages/join-page.tsx
@@ -1,0 +1,58 @@
+import { Form, Link } from "react-router";
+import type { Route } from "./+types/join-page";
+import InputPair from "~/common/components/intput-pair";
+import { Button } from "~/common/components/ui/button";
+
+export const meta: Route.MetaFunction = () => {
+  return [{ title: "Join | wemake" }];
+};
+
+export default function JoinPage() {
+  return (
+    <div className="flex flex-col items-center justify-center h-full">
+      <Button variant="ghost" asChild className="absolute right-8 top-8">
+        <Link to="/auth/login">Login</Link>
+      </Button>
+      <div className="flex items-center justify-center gap-10 flex-col w-full max-w-md">
+        <h1 className="text-2xl font-semibold">Create an account</h1>
+        <Form className="w-full space-y-4">
+          <InputPair
+            id="name"
+            label="Name"
+            description="Enter your name"
+            name="name"
+            type="text"
+            placeholder="Enter your name"
+          />
+          <InputPair
+            id="username"
+            label="Username"
+            description="Enter your username"
+            name="username"
+            type="text"
+            placeholder="i.e wemake"
+          />
+          <InputPair
+            id="email"
+            label="Email"
+            description="Enter your email"
+            name="email"
+            type="email"
+            placeholder="i.e wemake@gmail.com"
+          />
+          <InputPair
+            id="password"
+            label="Password"
+            description="Enter your password"
+            name="password"
+            type="password"
+            placeholder="Enter your password"
+          />
+          <Button type="submit" className="w-full">
+            Create account
+          </Button>
+        </Form>
+      </div>
+    </div>
+  );
+}

--- a/app/features/auth/pages/login-page.tsx
+++ b/app/features/auth/pages/login-page.tsx
@@ -1,0 +1,42 @@
+import { Button } from "~/common/components/ui/button";
+import { Form, Link } from "react-router";
+import type { Route } from "./+types/login-page";
+import InputPair from "~/common/components/intput-pair";
+
+export const meta: Route.MetaFunction = () => {
+  return [{ title: "Login | wemake" }];
+};
+
+export default function LoginPage() {
+  return (
+    <div className="flex flex-col items-center justify-center h-full">
+      <Button variant="ghost" asChild className="absolute right-8 top-8">
+        <Link to="/auth/join">Join</Link>
+      </Button>
+      <div className="flex items-center justify-center gap-10 flex-col w-full max-w-md">
+        <h1 className="text-2xl font-semibold">Login to your account</h1>
+        <Form className="w-full space-y-4">
+          <InputPair
+            id="email"
+            label="Email"
+            description="Enter your email"
+            name="email"
+            type="email"
+            placeholder="i.e wemake@gmail.com"
+          />
+          <InputPair
+            id="password"
+            label="Password"
+            description="Enter your password"
+            name="password"
+            type="password"
+            placeholder="Enter your password"
+          />
+          <Button type="submit" className="w-full">
+            Login
+          </Button>
+        </Form>
+      </div>
+    </div>
+  );
+}

--- a/app/features/auth/pages/otp-complete-page.tsx
+++ b/app/features/auth/pages/otp-complete-page.tsx
@@ -1,0 +1,13 @@
+import type { Route } from "../+types/otp-complete-page";
+
+export default function OtpCompletePage({
+  loaderData,
+  actionData,
+}: Route.ComponentProps) {
+  return (
+    <div className="flex flex-col space-y-2 text-center">
+      <h1 className="text-2xl font-semibold tracking-tight">OTP 인증 완료</h1>
+      <p className="text-sm text-muted-foreground">인증이 완료되었습니다</p>
+    </div>
+  );
+}

--- a/app/features/auth/pages/otp-start-page.tsx
+++ b/app/features/auth/pages/otp-start-page.tsx
@@ -1,0 +1,15 @@
+import type { Route } from "../+types/otp-start-page";
+
+export default function OtpStartPage({
+  loaderData,
+  actionData,
+}: Route.ComponentProps) {
+  return (
+    <div className="flex flex-col space-y-2 text-center">
+      <h1 className="text-2xl font-semibold tracking-tight">OTP 인증</h1>
+      <p className="text-sm text-muted-foreground">
+        이메일로 전송된 인증 코드를 입력하세요
+      </p>
+    </div>
+  );
+}

--- a/app/features/auth/pages/social-complete-page.tsx
+++ b/app/features/auth/pages/social-complete-page.tsx
@@ -1,0 +1,17 @@
+import type { Route } from "../+types/social-complete-page";
+
+export default function SocialCompletePage({
+  loaderData,
+  actionData,
+}: Route.ComponentProps) {
+  return (
+    <div className="flex flex-col space-y-2 text-center">
+      <h1 className="text-2xl font-semibold tracking-tight">
+        소셜 로그인 완료
+      </h1>
+      <p className="text-sm text-muted-foreground">
+        소셜 로그인이 완료되었습니다
+      </p>
+    </div>
+  );
+}

--- a/app/features/auth/pages/social-start-page.tsx
+++ b/app/features/auth/pages/social-start-page.tsx
@@ -1,0 +1,15 @@
+import type { Route } from "../+types/social-start-page";
+
+export default function SocialStartPage({
+  loaderData,
+  actionData,
+}: Route.ComponentProps) {
+  return (
+    <div className="flex flex-col space-y-2 text-center">
+      <h1 className="text-2xl font-semibold tracking-tight">소셜 로그인</h1>
+      <p className="text-sm text-muted-foreground">
+        소셜 계정으로 로그인하세요
+      </p>
+    </div>
+  );
+}

--- a/app/features/community/components/post-card.tsx
+++ b/app/features/community/components/post-card.tsx
@@ -1,14 +1,17 @@
+import { DotIcon } from "lucide-react";
 import { Link } from "react-router";
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+} from "~/common/components/ui/avatar";
+import { Button } from "~/common/components/ui/button";
 import {
   Card,
   CardFooter,
   CardHeader,
   CardTitle,
 } from "~/common/components/ui/card";
-import { Avatar, AvatarImage } from "~/common/components/ui/avatar";
-import { AvatarFallback } from "~/common/components/ui/avatar";
-import { Button } from "~/common/components/ui/button";
-import { DotIcon } from "lucide-react";
 
 interface PostCardProps {
   id: string;

--- a/app/features/ideas/components/idea-card.tsx
+++ b/app/features/ideas/components/idea-card.tsx
@@ -1,13 +1,13 @@
+import { DotIcon, EyeIcon, HeartIcon, LockIcon } from "lucide-react";
 import { Link } from "react-router";
+import { Button } from "~/common/components/ui/button";
 import {
   Card,
-  CardHeader,
-  CardTitle,
   CardContent,
   CardFooter,
+  CardHeader,
+  CardTitle,
 } from "~/common/components/ui/card";
-import { Button } from "~/common/components/ui/button";
-import { DotIcon, EyeIcon, HeartIcon, LockIcon } from "lucide-react";
 import { cn } from "~/lib/utils";
 
 interface IdeaCardProps {

--- a/app/features/ideas/pages/idea-page.tsx
+++ b/app/features/ideas/pages/idea-page.tsx
@@ -1,7 +1,7 @@
-import { Hero } from "~/common/components/hero";
-import type { Route } from "./+types/idea-page";
 import { DotIcon, EyeIcon, HeartIcon } from "lucide-react";
+import { Hero } from "~/common/components/hero";
 import { Button } from "~/common/components/ui/button";
+import type { Route } from "./+types/idea-page";
 
 export const meta: Route.MetaFunction = () => {
   return [

--- a/app/features/ideas/pages/ideas-page.tsx
+++ b/app/features/ideas/pages/ideas-page.tsx
@@ -1,6 +1,6 @@
 import { Hero } from "~/common/components/hero";
-import type { Route } from "./+types/ideas-page";
 import { IdeaCard } from "../components/idea-card";
+import type { Route } from "./+types/ideas-page";
 
 export const meta: Route.MetaFunction = () => {
   return [

--- a/app/features/jobs/components/job-card.tsx
+++ b/app/features/jobs/components/job-card.tsx
@@ -1,13 +1,13 @@
 import { Link } from "react-router";
+import { Badge } from "~/common/components/ui/badge";
+import { Button } from "~/common/components/ui/button";
 import {
   Card,
-  CardHeader,
-  CardTitle,
   CardContent,
   CardFooter,
+  CardHeader,
+  CardTitle,
 } from "~/common/components/ui/card";
-import { Button } from "~/common/components/ui/button";
-import { Badge } from "~/common/components/ui/badge";
 
 interface JobCardProps {
   id: string;

--- a/app/features/jobs/pages/job-page.tsx
+++ b/app/features/jobs/pages/job-page.tsx
@@ -1,7 +1,7 @@
-import { Badge } from "~/common/components/ui/badge";
-import type { Route } from "./+types/job-page";
 import { DotIcon } from "lucide-react";
+import { Badge } from "~/common/components/ui/badge";
 import { Button } from "~/common/components/ui/button";
+import type { Route } from "./+types/job-page";
 
 export const meta: Route.MetaFunction = () => [
   { title: "Job Details | wemake" },

--- a/app/features/jobs/pages/post-job-page.tsx
+++ b/app/features/jobs/pages/post-job-page.tsx
@@ -1,10 +1,10 @@
-import { Hero } from "~/common/components/hero";
-import type { Route } from "./+types/post-job-page";
 import { Form } from "react-router";
+import { Hero } from "~/common/components/hero";
 import InputPair from "~/common/components/intput-pair";
 import SelectPair from "~/common/components/select-pair";
-import { JOB_TYPES, LOCATION_TYPES, SALARY_RANGES } from "../constants";
 import { Button } from "~/common/components/ui/button";
+import { JOB_TYPES, LOCATION_TYPES, SALARY_RANGES } from "../constants";
+import type { Route } from "./+types/post-job-page";
 
 export const meta: Route.MetaFunction = () => [
   { title: "Post a Job | wemake" },

--- a/app/features/products/components/product-card.tsx
+++ b/app/features/products/components/product-card.tsx
@@ -1,4 +1,6 @@
+import { ChevronUpIcon, EyeIcon, MessageCircleIcon } from "lucide-react";
 import { Link } from "react-router";
+import { Button } from "~/common/components/ui/button";
 import {
   Card,
   CardDescription,
@@ -6,8 +8,6 @@ import {
   CardHeader,
   CardTitle,
 } from "~/common/components/ui/card";
-import { Button } from "~/common/components/ui/button";
-import { ChevronUpIcon, EyeIcon, MessageCircleIcon } from "lucide-react";
 
 interface ProductCardProps {
   id: string;

--- a/app/features/products/layouts/product-overview-layout.tsx
+++ b/app/features/products/layouts/product-overview-layout.tsx
@@ -1,5 +1,5 @@
 import { ChevronUpIcon, StarIcon } from "lucide-react";
-import { Link, NavLink, Outlet } from "react-router";
+import { NavLink, Outlet } from "react-router";
 import { Button, buttonVariants } from "~/common/components/ui/button";
 import { cn } from "~/lib/utils";
 

--- a/app/features/products/pages/leaderboards-page.tsx
+++ b/app/features/products/pages/leaderboards-page.tsx
@@ -1,8 +1,8 @@
+import { Link } from "react-router";
+import { Hero } from "~/common/components/hero";
 import { Button } from "~/common/components/ui/button";
 import { ProductCard } from "../components/product-card";
 import type { Route } from "./+types/leaderboards-page";
-import { Hero } from "~/common/components/hero";
-import { Link } from "react-router";
 
 export const meta: Route.MetaFunction = () => {
   return [

--- a/app/features/products/pages/leaderboards-redirection-page.tsx
+++ b/app/features/products/pages/leaderboards-redirection-page.tsx
@@ -1,6 +1,6 @@
+import { DateTime } from "luxon";
 import { data, redirect } from "react-router";
 import type { Route } from "./+types/leaderboards-redirection-page";
-import { DateTime } from "luxon";
 
 export function loader({ params }: Route.LoaderArgs) {
   const { period } = params;

--- a/app/features/products/pages/monthly-leaderboards-page.tsx
+++ b/app/features/products/pages/monthly-leaderboards-page.tsx
@@ -1,11 +1,11 @@
 import { DateTime } from "luxon";
-import type { Route } from "./+types/monthly-leaderboards-page";
 import { data, isRouteErrorResponse, Link } from "react-router";
 import { z } from "zod";
 import { Hero } from "~/common/components/hero";
-import { ProductCard } from "../components/product-card";
-import { Button } from "~/common/components/ui/button";
 import ProductPagination from "~/common/components/pagination";
+import { Button } from "~/common/components/ui/button";
+import { ProductCard } from "../components/product-card";
+import type { Route } from "./+types/monthly-leaderboards-page";
 
 const paramsSchema = z.object({
   year: z.coerce.number(),

--- a/app/features/products/pages/product-reviews-page.tsx
+++ b/app/features/products/pages/product-reviews-page.tsx
@@ -1,14 +1,7 @@
 import { Button } from "~/common/components/ui/button";
-import { ReviewCard } from "../components/review-card";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogDescription,
-  DialogTrigger,
-} from "~/common/components/ui/dialog";
+import { Dialog, DialogTrigger } from "~/common/components/ui/dialog";
 import { CreateReviewDialog } from "../components/create-review-dialog";
+import { ReviewCard } from "../components/review-card";
 
 export function meta() {
   return [

--- a/app/features/products/pages/promote-page.tsx
+++ b/app/features/products/pages/promote-page.tsx
@@ -1,13 +1,13 @@
-import { Hero } from "~/common/components/hero";
-import type { Route } from "./+types/promote-page";
-import { Form } from "react-router";
-import SelectPair from "~/common/components/select-pair";
-import { Calendar } from "~/common/components/ui/calendar";
-import { Label } from "~/common/components/ui/label";
+import { DateTime } from "luxon";
 import { useState } from "react";
 import type { DateRange } from "react-day-picker";
-import { DateTime } from "luxon";
+import { Form } from "react-router";
+import { Hero } from "~/common/components/hero";
+import SelectPair from "~/common/components/select-pair";
 import { Button } from "~/common/components/ui/button";
+import { Calendar } from "~/common/components/ui/calendar";
+import { Label } from "~/common/components/ui/label";
+import type { Route } from "./+types/promote-page";
 
 export const meta: Route.MetaFunction = () => {
   return [

--- a/app/features/products/pages/submit-page.tsx
+++ b/app/features/products/pages/submit-page.tsx
@@ -1,12 +1,12 @@
+import { useState } from "react";
 import { Form } from "react-router";
 import { Hero } from "~/common/components/hero";
-import type { Route } from "./+types/submit-page";
 import InputPair from "~/common/components/intput-pair";
 import SelectPair from "~/common/components/select-pair";
+import { Button } from "~/common/components/ui/button";
 import { Input } from "~/common/components/ui/input";
 import { Label } from "~/common/components/ui/label";
-import { useState } from "react";
-import { Button } from "~/common/components/ui/button";
+import type { Route } from "./+types/submit-page";
 export const meta: Route.MetaFunction = () => {
   return [
     { title: "Submit Product | wemake" },

--- a/app/features/products/pages/weekly-leaderboards-page.tsx
+++ b/app/features/products/pages/weekly-leaderboards-page.tsx
@@ -1,11 +1,11 @@
 import { DateTime } from "luxon";
-import type { Route } from "./+types/weekly-leaderboards-page";
 import { data, isRouteErrorResponse, Link } from "react-router";
 import { z } from "zod";
 import { Hero } from "~/common/components/hero";
-import { ProductCard } from "../components/product-card";
-import { Button } from "~/common/components/ui/button";
 import ProductPagination from "~/common/components/pagination";
+import { Button } from "~/common/components/ui/button";
+import { ProductCard } from "../components/product-card";
+import type { Route } from "./+types/weekly-leaderboards-page";
 
 const paramsSchema = z.object({
   year: z.coerce.number(),

--- a/app/features/products/pages/yearly-leaderboards-page.tsx
+++ b/app/features/products/pages/yearly-leaderboards-page.tsx
@@ -1,11 +1,11 @@
 import { DateTime } from "luxon";
-import type { Route } from "./+types/yearly-leaderboards-page";
 import { data, isRouteErrorResponse, Link } from "react-router";
 import { z } from "zod";
 import { Hero } from "~/common/components/hero";
-import { ProductCard } from "../components/product-card";
-import { Button } from "~/common/components/ui/button";
 import ProductPagination from "~/common/components/pagination";
+import { Button } from "~/common/components/ui/button";
+import { ProductCard } from "../components/product-card";
+import type { Route } from "./+types/yearly-leaderboards-page";
 
 const paramsSchema = z.object({
   year: z.coerce.number(),

--- a/app/features/teams/components/team-card.tsx
+++ b/app/features/teams/components/team-card.tsx
@@ -1,17 +1,17 @@
 import { Link } from "react-router";
 import {
-  Card,
-  CardHeader,
-  CardTitle,
-  CardFooter,
-} from "~/common/components/ui/card";
-import { Button } from "~/common/components/ui/button";
-import { Badge } from "~/common/components/ui/badge";
-import {
   Avatar,
   AvatarFallback,
   AvatarImage,
 } from "~/common/components/ui/avatar";
+import { Badge } from "~/common/components/ui/badge";
+import { Button } from "~/common/components/ui/button";
+import {
+  Card,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "~/common/components/ui/card";
 
 interface TeamCardProps {
   id: string;

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -5,6 +5,7 @@ import {
   Outlet,
   Scripts,
   ScrollRestoration,
+  useLocation,
 } from "react-router";
 
 import { Settings } from "luxon";
@@ -37,7 +38,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
         <Links />
       </head>
       <body>
-        <main className="px-20">{children}</main>
+        <main>{children}</main>
         <ScrollRestoration />
         <Scripts />
       </body>
@@ -46,13 +47,16 @@ export function Layout({ children }: { children: React.ReactNode }) {
 }
 
 export default function App() {
+  const { pathname } = useLocation();
   return (
-    <div className="py-28">
-      <Navigation
-        isLoggedIn={false}
-        hasNotifications={false}
-        hasMessages={false}
-      />
+    <div className={pathname.includes("/auth/") ? "" : "py-28 px-20"}>
+      {pathname.includes("/auth/") ? null : (
+        <Navigation
+          isLoggedIn={false}
+          hasNotifications={false}
+          hasMessages={false}
+        />
+      )}
       <Outlet />
     </div>
   );

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -59,4 +59,18 @@ export default [
     route("/:jobId", "features/jobs/pages/job-page.tsx"),
     route("/post", "features/jobs/pages/post-job-page.tsx"),
   ]),
+  ...prefix("/auth", [
+    layout("features/auth/layouts/auth-layout.tsx", [
+      route("/login", "features/auth/pages/login-page.tsx"),
+      route("/join", "features/auth/pages/join-page.tsx"),
+      ...prefix("/otp", [
+        route("/start", "features/auth/pages/otp-start-page.tsx"),
+        route("/complete", "features/auth/pages/otp-complete-page.tsx"),
+      ]),
+      ...prefix("/social/:provider", [
+        route("/start", "features/auth/pages/social-start-page.tsx"),
+        route("/complete", "features/auth/pages/social-complete-page.tsx"),
+      ]),
+    ]),
+  ]),
 ] satisfies RouteConfig;


### PR DESCRIPTION
- 회원가입 페이지(join-page.tsx)를 새로 생성하여 사용자 등록 UI 구현
- OTP 시작 페이지(otp-start-page.tsx) 추가로 이메일 인증 절차 안내
- 인증 관련 레이아웃(auth-layout.tsx) 추가, 화면 분할 디자인 적용
- App 컴포넌트에서 인증 경로(/auth/)일 때 네비게이션 숨기도록 수정
- 불필요한 import 정리 및 UI 컴포넌트 사용 일관성 개선

회원가입과 인증 흐름을 구축하여 사용자 경험을 향상시키기 위함