### PR TITLE
feat✨: OTP 인증 및 소셜 로그인 버튼 추가

### DIFF
--- a/app/features/auth/components/auth-buttons.tsx
+++ b/app/features/auth/components/auth-buttons.tsx
@@ -1,0 +1,38 @@
+import { GithubIcon, LockIcon, MessageCircleIcon } from "lucide-react";
+import { Link } from "react-router";
+import { Button } from "~/common/components/ui/button";
+import { Separator } from "~/common/components/ui/separator";
+
+export default function AuthButtons() {
+  return (
+    <div className="w-full flex flex-col items-center gap-10">
+      <div className="flex flex-col gap-2 w-full items-center">
+        <Separator className="w-full" />
+        <span className="text-xs text-muted-foreground uppercase font-medium">
+          Or continue with
+        </span>
+        <Separator className="w-full" />
+      </div>
+      <div className="flex flex-col gap-2 w-full">
+        <Button variant="outline" className="w-full" asChild>
+          <Link to="/auth/social/kakao/start">
+            <MessageCircleIcon className="size-4" />
+            Kakao Talk
+          </Link>
+        </Button>
+        <Button variant="outline" className="w-full" asChild>
+          <Link to="/auth/social/github/start">
+            <GithubIcon className="size-4" />
+            Github
+          </Link>
+        </Button>
+        <Button variant="outline" className="w-full" asChild>
+          <Link to="/auth/otp/start">
+            <LockIcon className="size-4" />
+            OTP
+          </Link>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/app/features/auth/pages/join-page.tsx
+++ b/app/features/auth/pages/join-page.tsx
@@ -2,7 +2,7 @@ import { Form, Link } from "react-router";
 import type { Route } from "./+types/join-page";
 import InputPair from "~/common/components/intput-pair";
 import { Button } from "~/common/components/ui/button";
-
+import AuthButtons from "../components/auth-buttons";
 export const meta: Route.MetaFunction = () => {
   return [{ title: "Join | wemake" }];
 };
@@ -52,6 +52,7 @@ export default function JoinPage() {
             Create account
           </Button>
         </Form>
+        <AuthButtons />
       </div>
     </div>
   );

--- a/app/features/auth/pages/login-page.tsx
+++ b/app/features/auth/pages/login-page.tsx
@@ -2,7 +2,7 @@ import { Button } from "~/common/components/ui/button";
 import { Form, Link } from "react-router";
 import type { Route } from "./+types/login-page";
 import InputPair from "~/common/components/intput-pair";
-
+import AuthButtons from "../components/auth-buttons";
 export const meta: Route.MetaFunction = () => {
   return [{ title: "Login | wemake" }];
 };
@@ -36,6 +36,7 @@ export default function LoginPage() {
             Login
           </Button>
         </Form>
+        <AuthButtons />
       </div>
     </div>
   );

--- a/app/features/auth/pages/otp-complete-page.tsx
+++ b/app/features/auth/pages/otp-complete-page.tsx
@@ -1,13 +1,44 @@
-import type { Route } from "../+types/otp-complete-page";
+import { Form } from "react-router";
+import InputPair from "~/common/components/intput-pair";
+import { Button } from "~/common/components/ui/button";
+import type { Route } from "./+types/otp-complete-page";
 
-export default function OtpCompletePage({
-  loaderData,
-  actionData,
-}: Route.ComponentProps) {
+export const meta: Route.MetaFunction = () => {
+  return [{ title: "OTP Complete | wemake" }];
+};
+
+export default function OtpCompletePage() {
   return (
-    <div className="flex flex-col space-y-2 text-center">
-      <h1 className="text-2xl font-semibold tracking-tight">OTP 인증 완료</h1>
-      <p className="text-sm text-muted-foreground">인증이 완료되었습니다</p>
+    <div className="flex flex-col items-center justify-center h-full">
+      <div className="flex items-center justify-center gap-10 flex-col w-full max-w-md">
+        <div className="text-center">
+          <h1 className="text-2xl font-semibold">Confirm OTP</h1>
+          <p className="text-sm text-muted-foreground">
+            Enter the OTP code sent to your email address.
+          </p>
+        </div>
+        <Form className="w-full space-y-4">
+          <InputPair
+            id="email"
+            label="Email"
+            description="Enter your email"
+            name="email"
+            type="email"
+            placeholder="i.e wemake@gmail.com"
+          />
+          <InputPair
+            id="otp"
+            label="OTP"
+            description="Enter the OTP code"
+            name="otp"
+            type="number"
+            placeholder="i.e 1234"
+          />
+          <Button type="submit" className="w-full">
+            Login
+          </Button>
+        </Form>
+      </div>
     </div>
   );
 }

--- a/app/features/auth/pages/otp-start-page.tsx
+++ b/app/features/auth/pages/otp-start-page.tsx
@@ -1,15 +1,36 @@
-import type { Route } from "../+types/otp-start-page";
+import { Form } from "react-router";
+import type { Route } from "./+types/otp-start-page";
+import InputPair from "~/common/components/intput-pair";
+import { Button } from "~/common/components/ui/button";
 
-export default function OtpStartPage({
-  loaderData,
-  actionData,
-}: Route.ComponentProps) {
+export const meta: Route.MetaFunction = () => {
+  return [{ title: "OTP Start | wemake" }];
+};
+
+export default function OtpStartPage() {
   return (
-    <div className="flex flex-col space-y-2 text-center">
-      <h1 className="text-2xl font-semibold tracking-tight">OTP 인증</h1>
-      <p className="text-sm text-muted-foreground">
-        이메일로 전송된 인증 코드를 입력하세요
-      </p>
+    <div className="flex flex-col items-center justify-center h-full">
+      <div className="flex items-center justify-center gap-10 flex-col w-full max-w-md">
+        <div className="text-center">
+          <h1 className="text-2xl font-semibold">Login with OTP</h1>
+          <p className="text-sm text-muted-foreground">
+            We will send you a 4-digit code to login to your account.
+          </p>
+        </div>
+        <Form className="w-full space-y-4">
+          <InputPair
+            id="email"
+            label="Email"
+            description="Enter your email"
+            name="email"
+            type="email"
+            placeholder="i.e wemake@gmail.com"
+          />
+          <Button type="submit" className="w-full">
+            Send OTP
+          </Button>
+        </Form>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
- OTP 시작 및 완료 페이지에 입력 폼과 메타 정보 추가  
- OTP 완료 페이지 UI 개선 및 사용자 안내 문구 추가  
- 로그인 및 회원가입 페이지에 소셜 로그인(AuthButtons) 컴포넌트 통합  
- AuthButtons 컴포넌트 생성, 카카오톡, 깃허브, OTP 소셜 로그인 버튼 제공  
- 사용자 인증 흐름을 직관적으로 개선하고 다양한 로그인 옵션 지원을 위해 변경