### PR TITLE
✨ feat: 팀 생성 및 팀 목록 페이지 추가

### DIFF
--- a/app/common/components/navigation.tsx
+++ b/app/common/components/navigation.tsx
@@ -115,7 +115,7 @@ const menus = [
       {
         name: "Create a Post",
         description: "Create a post in our community",
-        to: "/community/create",
+        to: "/community/submit",
       },
     ],
   },

--- a/app/features/teams/pages/create-team-page.tsx
+++ b/app/features/teams/pages/create-team-page.tsx
@@ -1,0 +1,94 @@
+import { Hero } from "~/common/components/hero";
+
+import { Form } from "react-router";
+import InputPair from "~/common/components/intput-pair";
+import SelectPair from "~/common/components/select-pair";
+import { Button } from "~/common/components/ui/button";
+import type { Route } from "./+types/create-team-page";
+
+export const meta: Route.MetaFunction = () => {
+  return [
+    {
+      title: "Submit Team | wemake",
+    },
+  ];
+};
+
+export default function SubmitTeamPage() {
+  return (
+    <div className="space-y-20">
+      <Hero
+        title="Submit Team"
+        subtitle="Create a team to the wemake community"
+      />
+      <Form className="max-w-screen-2xl mx-auto flex flex-col gap-10 items-center">
+        <div className="grid grid-cols-3 gap-10 w-full">
+          <InputPair
+            label="What is the name of your product?"
+            placeholder="i.e Doggy Social"
+            description="(20 characters or less)"
+            maxLength={20}
+            name="name"
+            id="name"
+            type="text"
+            required
+          />
+          <SelectPair
+            label="What is the stage of your product?"
+            description="Select the stage of your product"
+            name="stage"
+            placeholder="Select a stage"
+            required
+            options={[
+              { label: "Idea", value: "idea" },
+              { label: "Prototype", value: "prototype" },
+              { label: "MVP", value: "mvp" },
+              { label: "Product", value: "product" },
+            ]}
+          />
+          <InputPair
+            label="What is the size of your team?"
+            description="(1-100)"
+            name="size"
+            id="size"
+            type="number"
+            min={1}
+            max={100}
+            required
+          />
+          <InputPair
+            label="How many equity are you willing to give?"
+            description="(each)"
+            name="equity"
+            id="equity"
+            type="number"
+            min={1}
+            max={100}
+            required
+          />
+          <InputPair
+            label="What roles are you looking for?"
+            placeholder="i.e React Developer, Backend Developer, Product Manager"
+            description="(comma separated)"
+            name="roles"
+            id="roles"
+            type="text"
+            required
+          />
+          <InputPair
+            label="What is the description of your product?"
+            placeholder="i.e We are building a new social media platform for dogs to connect with each other"
+            description="(200 characters max)"
+            name="description"
+            id="description"
+            type="text"
+            textarea
+          />
+        </div>
+        <Button type="submit" className="w-full max-w-sm" size="lg">
+          Create team
+        </Button>
+      </Form>
+    </div>
+  );
+}

--- a/app/features/teams/pages/team-page.tsx
+++ b/app/features/teams/pages/team-page.tsx
@@ -1,0 +1,13 @@
+import type { Route } from "./+types/team-page";
+
+export const meta: Route.MetaFunction = () => {
+  return [
+    {
+      title: "Team | wemake",
+    },
+  ];
+};
+
+export default function TeamPage() {
+  return <div>TeamPage</div>;
+}

--- a/app/features/teams/pages/teams-page.tsx
+++ b/app/features/teams/pages/teams-page.tsx
@@ -1,0 +1,36 @@
+import { Hero } from "~/common/components/hero";
+import type { Route } from "./+types/teams-page";
+import { TeamCard } from "../components/team-card";
+
+export const meta: Route.MetaFunction = () => {
+  return [
+    {
+      title: "Teams | wemake",
+      description: "Teams page",
+    },
+  ];
+};
+
+export default function TeamsPage() {
+  return (
+    <div className="space-y-20">
+      <Hero title="Teams" subtitle="Find a team looking for a new member" />
+      <div className="grid grid-cols-4 gap-4">
+        {Array.from({ length: 11 }, (_, index) => (
+          <TeamCard
+            key={index}
+            id={`team-${index}`}
+            leaderUsername="lynn"
+            leaderAvatarUrl="https://github.com/inthetiger.png"
+            positions={[
+              "React Developer",
+              "Backend Developer",
+              "Product Manager",
+            ]}
+            projectDescription="a new social media platform"
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -78,4 +78,9 @@ export default [
     route("/:postId", "features/community/pages/post-page.tsx"),
     route("/submit", "features/community/pages/submit-post-page.tsx"),
   ]),
+  ...prefix("/teams", [
+    index("features/teams/pages/teams-page.tsx"),
+    route("/:teamId", "features/teams/pages/team-page.tsx"),
+    route("/create", "features/teams/pages/create-team-page.tsx"),
+  ]),
 ] satisfies RouteConfig;


### PR DESCRIPTION
- 팀 생성 페이지(create-team-page.tsx) 추가로 팀 정보 입력 및 제출 기능 구현  
- 팀 목록 페이지(teams-page.tsx) 및 팀 상세 페이지(team-page.tsx) 기본 구조 추가  
- 라우트(routes.ts)에 팀 관련 경로(/teams, /teams/create 등) 등록  
- 내비게이션 메뉴에서 게시물 생성 경로를 /community/create에서 /community/submit으로 수정  
- 팀 카드 컴포넌트를 활용해 팀 목록 UI 구성