### PR TITLE
✨ feat: 홈 페이지에 리플 효과 및 최신 채용 공고 추가

### DIFF
--- a/app/app.css
+++ b/app/app.css
@@ -132,7 +132,16 @@
     transform: translateY(calc(-100% - var(--gap)));
     }
   }
-}
+  --animate-ripple: ripple var(--duration,2s) ease calc(var(--i, 0)*.2s) infinite
+;
+  @keyframes ripple {
+  0%, 100% {
+    transform: translate(-50%, -50%) scale(1);
+    }
+  50% {
+    transform: translate(-50%, -50%) scale(0.9);
+    }
+  }}
 
 @layer base {
   * {

--- a/app/common/pages/home-page.tsx
+++ b/app/common/pages/home-page.tsx
@@ -7,6 +7,7 @@ import { TeamCard } from "~/features/teams/components/team-card";
 import { Button } from "../components/ui/button";
 import { FlickeringGrid } from "components/magicui/flickering-grid";
 import { VelocityScroll } from "components/magicui/scroll-based-velocity";
+import { Ripple } from "components/magicui/ripple";
 export const meta: MetaFunction = () => {
   return [
     { title: "Home | wemake" },
@@ -104,8 +105,8 @@ export default function HomePage() {
           />
         ))}
       </div>
-      <div className="grid grid-cols-3 gap-4">
-        <div>
+      <div className="mt-44 overflow-hidden">
+        <div className="relative flex h-[700px] w-full flex-col items-center justify-center overflow-hidden bg-background">
           <h2 className="text-5xl font-bold leading-tight tracking-tighter">
             Latest Jobs
           </h2>
@@ -115,21 +116,24 @@ export default function HomePage() {
           <Button variant="link" asChild className="text-lg p-0">
             <Link to="/jobs">Explore all jobs &rarr;</Link>
           </Button>
+          <Ripple />
         </div>
-        {Array.from({ length: 11 }, (_, index) => (
-          <JobCard
-            key={index}
-            id="jobId"
-            company="Meta"
-            companyLogoUrl="https://github.com/facebook.png"
-            companyHq="San Francisco, CA"
-            title="Software Engineer"
-            postedAt="12 hours ago"
-            type="Full-time"
-            positionLocation="Remote"
-            salary="$100,000 - $120,000"
-          />
-        ))}
+        <div className="grid grid-cols-3 gap-4">
+          {Array.from({ length: 12 }, (_, index) => (
+            <JobCard
+              key={index}
+              id="jobId"
+              company="Meta"
+              companyLogoUrl="https://github.com/facebook.png"
+              companyHq="San Francisco, CA"
+              title="Software Engineer"
+              postedAt="12 hours ago"
+              type="Full-time"
+              positionLocation="Remote"
+              salary="$100,000 - $120,000"
+            />
+          ))}
+        </div>
       </div>
       <div className="grid grid-cols-3 gap-4">
         <div>

--- a/components/magicui/ripple.tsx
+++ b/components/magicui/ripple.tsx
@@ -1,0 +1,59 @@
+import React, { ComponentPropsWithoutRef, CSSProperties } from "react";
+
+import { cn } from "~/lib/utils";
+
+interface RippleProps extends ComponentPropsWithoutRef<"div"> {
+  mainCircleSize?: number;
+  mainCircleOpacity?: number;
+  numCircles?: number;
+}
+
+export const Ripple = React.memo(function Ripple({
+  mainCircleSize = 210,
+  mainCircleOpacity = 0.24,
+  numCircles = 8,
+  className,
+  ...props
+}: RippleProps) {
+  return (
+    <div
+      className={cn(
+        "pointer-events-none absolute inset-0 select-none [mask-image:linear-gradient(to_bottom,white,transparent)]",
+        className,
+      )}
+      {...props}
+    >
+      {Array.from({ length: numCircles }, (_, i) => {
+        const size = mainCircleSize + i * 70;
+        const opacity = mainCircleOpacity - i * 0.03;
+        const animationDelay = `${i * 0.06}s`;
+        const borderStyle = i === numCircles - 1 ? "dashed" : "solid";
+        const borderOpacity = 5 + i * 5;
+
+        return (
+          <div
+            key={i}
+            className={`absolute animate-ripple rounded-full border bg-foreground/25 shadow-xl`}
+            style={
+              {
+                "--i": i,
+                width: `${size}px`,
+                height: `${size}px`,
+                opacity,
+                animationDelay,
+                borderStyle,
+                borderWidth: "1px",
+                borderColor: `hsl(var(--foreground), ${borderOpacity / 100})`,
+                top: "50%",
+                left: "50%",
+                transform: "translate(-50%, -50%) scale(1)",
+              } as CSSProperties
+            }
+          />
+        );
+      })}
+    </div>
+  );
+});
+
+Ripple.displayName = "Ripple";


### PR DESCRIPTION
- 홈 페이지에 리플(Ripple) 효과 컴포넌트 도입  
- 최신 채용 공고 섹션 추가  
- 채용 공고 리스트를 11개에서 12개로 확장  
- 레이아웃 개선으로 가독성 향상