### PR TITLE
✨ feat: 대시보드 레이아웃 및 아이디어 페이지 추가

### DIFF
--- a/app/features/ideas/components/idea-card.tsx
+++ b/app/features/ideas/components/idea-card.tsx
@@ -16,7 +16,7 @@ interface IdeaCardProps {
   viewCount: number;
   createdAt: string;
   likeCount: number;
-  claimed: boolean;
+  claimed?: boolean;
 }
 
 export function IdeaCard({
@@ -25,7 +25,7 @@ export function IdeaCard({
   viewCount,
   createdAt,
   likeCount,
-  claimed,
+  claimed = false,
 }: IdeaCardProps) {
   return (
     <Card className="bg-transparent hover:bg-card/50 transition-colors">

--- a/app/features/users/layouts/dashboard-layout.tsx
+++ b/app/features/users/layouts/dashboard-layout.tsx
@@ -1,0 +1,69 @@
+import { HomeIcon, PackageIcon, RocketIcon, SparklesIcon } from "lucide-react";
+import { Link, Outlet, useLocation } from "react-router";
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarGroup,
+  SidebarGroupLabel,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarProvider,
+} from "~/common/components/ui/sidebar";
+
+export default function DashboardLayout() {
+  const location = useLocation();
+  return (
+    <SidebarProvider className="flex min-h-full">
+      <Sidebar variant="floating" className="pt-16">
+        <SidebarContent>
+          <SidebarGroup>
+            <SidebarMenu>
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  asChild
+                  isActive={location.pathname === "/my/dashboard"}
+                >
+                  <Link to="/my/dashboard">
+                    <HomeIcon className="size-4" />
+                    <span>Home</span>
+                  </Link>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  asChild
+                  isActive={location.pathname === "/my/dashboard/ideas"}
+                >
+                  <Link to="/my/dashboard/ideas">
+                    <SparklesIcon className="size-4" />
+                    <span>Ideas</span>
+                  </Link>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            </SidebarMenu>
+          </SidebarGroup>
+          <SidebarGroup>
+            <SidebarGroupLabel>Product Analytics</SidebarGroupLabel>
+            <SidebarMenu>
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  asChild
+                  isActive={location.pathname === "/my/dashboard/products/1"}
+                >
+                  <Link to="/my/dashboard/products/1">
+                    <RocketIcon className="size-4" />
+                    <span>Product 1</span>
+                  </Link>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            </SidebarMenu>
+          </SidebarGroup>
+        </SidebarContent>
+      </Sidebar>
+      <div className="h-full">
+        <Outlet />
+      </div>
+    </SidebarProvider>
+  );
+}

--- a/app/features/users/layouts/messages-layout.tsx
+++ b/app/features/users/layouts/messages-layout.tsx
@@ -10,7 +10,7 @@ import { MessagesCard } from "../components/messages-card";
 
 export default function MessagesLayout() {
   return (
-    <SidebarProvider className="max-h-[calc(100vh-14rem)] overflow-hidden h-[calc(100vh-14rem)] min-h-full">
+    <SidebarProvider className="flex max-h-[calc(100vh-14rem)] overflow-hidden h-[calc(100vh-14rem)] min-h-full">
       <Sidebar variant="floating" className="pt-16">
         <SidebarContent>
           <SidebarGroup>

--- a/app/features/users/pages/dashboard-ideas-page.tsx
+++ b/app/features/users/pages/dashboard-ideas-page.tsx
@@ -1,7 +1,26 @@
-import type { FC } from "react";
+import { IdeaCard } from "~/features/ideas/components/idea-card";
+import type { Route } from "./+types/dashboard-ideas-page";
 
-export const DashboardIdeasPage: FC = function DashboardIdeasPage() {
-  return <div>DashboardIdeasPage</div>;
+export const meta: Route.MetaFunction = () => {
+  return [{ title: "My Ideas | wemake" }];
 };
 
-export default DashboardIdeasPage;
+export default function DashboardIdeasPage() {
+  return (
+    <div className="space-y-10 h-full">
+      <h1 className="text-2xl font-semibold mb-6">Claimed Ideas</h1>
+      <div className="grid grid-cols-4 gap-6">
+        {Array.from({ length: 5 }).map((_, index) => (
+          <IdeaCard
+            key={`ideaId-${index}`}
+            id={`ideaId-${index}`}
+            title="A startup that creates an AI-powered generated personal trainer, delivering customized fitness recommendations and tracking of progress using a mobile app to track workouts and progress as well as a website to manage the business."
+            viewCount={123}
+            createdAt="12 hours ago"
+            likeCount={12}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -84,13 +84,15 @@ export default [
     route("/create", "features/teams/pages/create-team-page.tsx"),
   ]),
   ...prefix("my", [
-    ...prefix("/dashboard", [
-      index("features/users/pages/dashboard-page.tsx"),
-      route("/ideas", "features/users/pages/dashboard-ideas-page.tsx"),
-      route(
-        "/products/:productId",
-        "features/users/pages/dashboard-product-page.tsx"
-      ),
+    layout("features/users/layouts/dashboard-layout.tsx", [
+      ...prefix("/dashboard", [
+        index("features/users/pages/dashboard-page.tsx"),
+        route("/ideas", "features/users/pages/dashboard-ideas-page.tsx"),
+        route(
+          "/products/:productId",
+          "features/users/pages/dashboard-product-page.tsx"
+        ),
+      ]),
     ]),
     route("/profile", "features/users/pages/my-profile-page.tsx"),
     route("/settings", "features/users/pages/settings-page.tsx"),


### PR DESCRIPTION
- 대시보드 레이아웃 컴포넌트 추가로 사이드바 내비게이션 구현
- /my/dashboard 경로에 대시보드 페이지 및 아이디어 목록 페이지 추가
- 아이디어 카드 컴포넌트에 claimed 선택적 속성 및 기본값 false 설정
- 메시지 레이아웃에 flex 클래스 추가로 레이아웃 개선
- 라우트 설정에 대시보드 레이아웃 적용하여 구조화된 라우팅 지원

대시보드 기능 확장과 UI 개선을 위해 변경함