### PR TITLE
feat: 채용 공고용 jobs 테이블 및 관련 enum 타입 추가

### DIFF
--- a/app/features/jobs/schema.ts
+++ b/app/features/jobs/schema.ts
@@ -1,0 +1,31 @@
+import { bigint, pgEnum, pgTable, text, timestamp } from "drizzle-orm/pg-core";
+import { JOB_TYPES, LOCATION_TYPES, SALARY_RANGES } from "./constants";
+
+export const jobTypes = pgEnum(
+  "job_types",
+  JOB_TYPES.map((type) => type.value) as [string, ...string[]]
+);
+export const locations = pgEnum(
+  "locations",
+  LOCATION_TYPES.map((type) => type.value) as [string, ...string[]]
+);
+export const salaryRanges = pgEnum("salary_ranges", SALARY_RANGES);
+
+export const jobs = pgTable("jobs", {
+  job_id: bigint({ mode: "number" }).primaryKey().generatedAlwaysAsIdentity(),
+  position: text().notNull(),
+  overview: text().notNull(),
+  responsibilities: text().notNull(),
+  qualifications: text().notNull(),
+  benefits: text().notNull(),
+  skills: text().notNull(),
+  company_name: text().notNull(),
+  company_logo: text().notNull(),
+  company_location: text().notNull(),
+  apply_url: text().notNull(),
+  job_type: jobTypes().notNull(),
+  location: locations().notNull(),
+  salary_range: salaryRanges().notNull(),
+  created_at: timestamp().notNull().defaultNow(),
+  updated_at: timestamp().notNull().defaultNow(),
+});

--- a/app/migrations/0000_needy_jetstream.sql
+++ b/app/migrations/0000_needy_jetstream.sql
@@ -1,0 +1,21 @@
+CREATE TYPE "public"."job_types" AS ENUM('full-time', 'part-time', 'freelance', 'internship');--> statement-breakpoint
+CREATE TYPE "public"."locations" AS ENUM('remote', 'in-person', 'hybrid');--> statement-breakpoint
+CREATE TYPE "public"."salary_ranges" AS ENUM('$0 - $50,000', '$50,000 - $70,000', '$70,000 - $100,000', '$100,000 - $120,000', '$120,000 - $150,000', '$150,000 - $250,000', '$250,000+');--> statement-breakpoint
+CREATE TABLE "jobs" (
+	"job_id" bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "jobs_job_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 CACHE 1),
+	"position" text NOT NULL,
+	"overview" text NOT NULL,
+	"responsibilities" text NOT NULL,
+	"qualifications" text NOT NULL,
+	"benefits" text NOT NULL,
+	"skills" text NOT NULL,
+	"company_name" text NOT NULL,
+	"company_logo" text NOT NULL,
+	"company_location" text NOT NULL,
+	"apply_url" text NOT NULL,
+	"job_type" "job_types" NOT NULL,
+	"location" "locations" NOT NULL,
+	"salary_range" "salary_ranges" NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);

--- a/app/migrations/meta/0000_snapshot.json
+++ b/app/migrations/meta/0000_snapshot.json
@@ -1,0 +1,177 @@
+{
+  "id": "0900992d-1d43-48d0-94dc-8d65ebe7e248",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.jobs": {
+      "name": "jobs",
+      "schema": "",
+      "columns": {
+        "job_id": {
+          "name": "job_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "jobs_job_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overview": {
+          "name": "overview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "responsibilities": {
+          "name": "responsibilities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "qualifications": {
+          "name": "qualifications",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "benefits": {
+          "name": "benefits",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skills": {
+          "name": "skills",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_name": {
+          "name": "company_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_logo": {
+          "name": "company_logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_location": {
+          "name": "company_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "apply_url": {
+          "name": "apply_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_type": {
+          "name": "job_type",
+          "type": "job_types",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "locations",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "salary_range": {
+          "name": "salary_range",
+          "type": "salary_ranges",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.job_types": {
+      "name": "job_types",
+      "schema": "public",
+      "values": [
+        "full-time",
+        "part-time",
+        "freelance",
+        "internship"
+      ]
+    },
+    "public.locations": {
+      "name": "locations",
+      "schema": "public",
+      "values": [
+        "remote",
+        "in-person",
+        "hybrid"
+      ]
+    },
+    "public.salary_ranges": {
+      "name": "salary_ranges",
+      "schema": "public",
+      "values": [
+        "$0 - $50,000",
+        "$50,000 - $70,000",
+        "$70,000 - $100,000",
+        "$100,000 - $120,000",
+        "$120,000 - $150,000",
+        "$150,000 - $250,000",
+        "$250,000+"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/app/migrations/meta/_journal.json
+++ b/app/migrations/meta/_journal.json
@@ -1,0 +1,20 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1747834307991,
+      "tag": "0000_needy_jetstream",
+      "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1747835353329,
+      "tag": "0001_giant_valeria_richards",
+      "breakpoints": true
+    }
+  ]
+}


### PR DESCRIPTION
- 신규 jobs 테이블 생성  
- 포지션, 개요, 책임, 자격 요건, 혜택, 기술, 회사 정보, 지원 URL 등 다양한 필드 포함  
- job_types, locations, salary_ranges 세 가지 enum 타입 추가  
- 데이터 무결성과 일관성 확보 위한 타입 정의

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #55 
- <kbd>&nbsp;2&nbsp;</kbd> #54 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #53 
<!-- GitButler Footer Boundary Bottom -->

