### PR TITLE
feat: 커뮤니티 게시글 리스트 뷰 추가 및 관련 코드 개선

### DIFF
--- a/app/features/community/pages/community-page.tsx
+++ b/app/features/community/pages/community-page.tsx
@@ -109,12 +109,12 @@ export default function CommunityPage({ loaderData }: Route.ComponentProps) {
                 key={post.post_id}
                 id={post.post_id}
                 title={post.title}
-                author={post.author.name}
-                authorAvatarUrl={post.author.avatar}
-                category={post.topic.name}
+                author={post.author}
+                authorAvatarUrl={post.author_avatar}
+                category={post.topic}
                 postedAt={post.created_at}
                 expanded={true}
-                votesCount={post.upvotes[0].count}
+                votesCount={post.upvotes}
               />
             ))}
           </div>

--- a/app/features/community/queries.ts
+++ b/app/features/community/queries.ts
@@ -49,22 +49,10 @@ export const getTopics = async () => {
 };
 
 export const getPosts = async () => {
-  const { data, error } = await client.from("posts").select(`
-        post_id,
-        title,
-        created_at,
-        topic:topics!inner(
-            name
-        ),
-        author:profiles!posts_profile_id_profiles_profile_id_fk!inner(
-            name,
-            avatar,
-            username
-        ),
-        upvotes:post_upvotes(
-            count
-        )
-    `);
+  const { data, error } = await client
+    .from("community_post_list_view")
+    .select("*")
+    .order("post_id");
   if (error) throw new Error(error.message);
   return data;
 };

--- a/app/sql/views/community-post-list-view.sql
+++ b/app/sql/views/community-post-list-view.sql
@@ -1,0 +1,15 @@
+CREATE VIEW community_post_list_view AS
+SELECT
+    posts.post_id,
+    posts.title,
+    posts.created_at,
+    topics.name as topic,
+    profiles.name as author,
+    profiles.avatar as author_avatar,
+    profiles.username as author_username,
+    COUNT(post_upvotes.post_id) as upvotes
+FROM posts
+INNER JOIN topics USING (topic_id)
+INNER JOIN profiles USING (profile_id)
+LEFT JOIN post_upvotes USING (post_id)
+GROUP BY posts.post_id, topics.name, profiles.name, profiles.avatar, profiles.username;

--- a/app/supa-client.ts
+++ b/app/supa-client.ts
@@ -1,5 +1,25 @@
 import { createClient } from "@supabase/supabase-js";
-import type { Database } from "database.types";
+import type { Database as SupabaseDatabase } from "database.types";
+import type { MergeDeep, SetNonNullable, SetFieldType } from "type-fest";
+
+type Database = MergeDeep<
+  SupabaseDatabase,
+  {
+    public: {
+      Views: {
+        community_post_list_view: {
+          Row: SetFieldType<
+            SetNonNullable<
+              SupabaseDatabase["public"]["Views"]["community_post_list_view"]["Row"]
+            >,
+            "author_avatar",
+            string | null
+          >;
+        };
+      };
+    };
+  }
+>;
 
 const client = createClient<Database>(
   process.env.SUPABASE_URL!,

--- a/database.types.ts
+++ b/database.types.ts
@@ -308,6 +308,13 @@ export type Database = {
             foreignKeyName: "notifications_post_id_posts_post_id_fk"
             columns: ["post_id"]
             isOneToOne: false
+            referencedRelation: "community_post_list_view"
+            referencedColumns: ["post_id"]
+          },
+          {
+            foreignKeyName: "notifications_post_id_posts_post_id_fk"
+            columns: ["post_id"]
+            isOneToOne: false
             referencedRelation: "posts"
             referencedColumns: ["post_id"]
           },
@@ -374,6 +381,13 @@ export type Database = {
             foreignKeyName: "post_replies_post_id_posts_post_id_fk"
             columns: ["post_id"]
             isOneToOne: false
+            referencedRelation: "community_post_list_view"
+            referencedColumns: ["post_id"]
+          },
+          {
+            foreignKeyName: "post_replies_post_id_posts_post_id_fk"
+            columns: ["post_id"]
+            isOneToOne: false
             referencedRelation: "posts"
             referencedColumns: ["post_id"]
           },
@@ -400,6 +414,13 @@ export type Database = {
           profile_id?: string
         }
         Relationships: [
+          {
+            foreignKeyName: "post_upvotes_post_id_posts_post_id_fk"
+            columns: ["post_id"]
+            isOneToOne: false
+            referencedRelation: "community_post_list_view"
+            referencedColumns: ["post_id"]
+          },
           {
             foreignKeyName: "post_upvotes_post_id_posts_post_id_fk"
             columns: ["post_id"]
@@ -700,7 +721,19 @@ export type Database = {
       }
     }
     Views: {
-      [_ in never]: never
+      community_post_list_view: {
+        Row: {
+          author: string | null
+          author_avatar: string | null
+          author_username: string | null
+          created_at: string | null
+          post_id: number | null
+          title: string | null
+          topic: string | null
+          upvotes: number | null
+        }
+        Relationships: []
+      }
     }
     Functions: {
       [_ in never]: never

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "recharts": "^2.15.3",
         "tailwind-merge": "^3.0.2",
         "tw-animate-css": "^1.2.5",
+        "type-fest": "^4.41.0",
         "zod": "^3.24.3"
       },
       "devDependencies": {
@@ -9880,6 +9881,18 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Wombosvideo"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/type-is": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "recharts": "^2.15.3",
     "tailwind-merge": "^3.0.2",
     "tw-animate-css": "^1.2.5",
+    "type-fest": "^4.41.0",
     "zod": "^3.24.3"
   },
   "devDependencies": {


### PR DESCRIPTION
- community_post_list_view 뷰를 생성하여 게시글과 관련된 정보(작성자, 토픽, 추천수)를 한 번에 조회할 수 있도록 함  
- 기존 posts 테이블 조인 쿼리를 뷰로 대체하여 쿼리 간소화 및 성능 개선  
- 타입 정의에 뷰를 반영하고, Supabase 클라이언트 타입도 업데이트  
- 커뮤니티 페이지 컴포넌트에서 뷰 기반 데이터 구조에 맞게 props 수정  
- package.json에 type-fest 라이브러리 추가하여 타입 유틸리티 활용 가능하게 함