### PR TITLE
feat: 날짜별 리더보드에 페이징 기능 추가 및 데이터 로딩 개선

### DIFF
--- a/app/common/pages/home-page.tsx
+++ b/app/common/pages/home-page.tsx
@@ -26,6 +26,7 @@ export const loader = async () => {
     startDate: DateTime.now().startOf("day"),
     endDate: DateTime.now().endOf("day"),
     limit: 8,
+    page: 1,
   });
   return { dailyProducts };
 };

--- a/app/features/products/constants.ts
+++ b/app/features/products/constants.ts
@@ -1,0 +1,1 @@
+export const PAGE_SIZE = 2;

--- a/app/features/products/layouts/leaderboard-layout.tsx
+++ b/app/features/products/layouts/leaderboard-layout.tsx
@@ -1,0 +1,23 @@
+import { data, Outlet } from "react-router";
+import { z } from "zod";
+import type { Route } from "./+types/leaderboard-layout";
+
+const searchParamsSchema = z.object({
+  page: z.coerce.number().min(1).optional().default(1),
+});
+
+export const loader = async ({ request }: Route.LoaderArgs) => {
+  const url = new URL(request.url);
+  const { success: pageParseSuccess, data: parsedPage } =
+    searchParamsSchema.safeParse(Object.fromEntries(url.searchParams));
+  if (!pageParseSuccess) {
+    throw data(
+      { error_code: "invalid page", message: "Invalid page" },
+      { status: 400 }
+    );
+  }
+};
+
+export default function LeaderboardLayout() {
+  return <Outlet />;
+}

--- a/app/features/products/pages/leaderboards-page.tsx
+++ b/app/features/products/pages/leaderboards-page.tsx
@@ -20,21 +20,25 @@ export const loader = async () => {
         startDate: DateTime.now().startOf("day"),
         endDate: DateTime.now().endOf("day"),
         limit: 8,
+        page: 1,
       }),
       getProductsByDateRange({
         startDate: DateTime.now().startOf("week"),
         endDate: DateTime.now().endOf("week"),
         limit: 8,
+        page: 1,
       }),
       getProductsByDateRange({
         startDate: DateTime.now().startOf("month"),
         endDate: DateTime.now().endOf("month"),
         limit: 8,
+        page: 1,
       }),
       getProductsByDateRange({
         startDate: DateTime.now().startOf("year"),
         endDate: DateTime.now().endOf("year"),
         limit: 8,
+        page: 1,
       }),
     ]);
 

--- a/app/features/products/pages/monthly-leaderboards-page.tsx
+++ b/app/features/products/pages/monthly-leaderboards-page.tsx
@@ -5,6 +5,7 @@ import { Hero } from "~/common/components/hero";
 import ProductPagination from "~/common/components/pagination";
 import { Button } from "~/common/components/ui/button";
 import { ProductCard } from "../components/product-card";
+import { getProductPagesByDateRange, getProductsByDateRange } from "../queries";
 import type { Route } from "./+types/monthly-leaderboards-page";
 
 const paramsSchema = z.object({
@@ -28,7 +29,7 @@ export const meta: Route.MetaFunction = ({ params }) => {
   ];
 };
 
-export const loader = ({ params }: Route.LoaderArgs) => {
+export const loader = async ({ params, request }: Route.LoaderArgs) => {
   const { success, data: parsedData } = paramsSchema.safeParse(params);
 
   if (!success) {
@@ -57,8 +58,21 @@ export const loader = ({ params }: Route.LoaderArgs) => {
     );
   }
 
+  const url = new URL(request.url);
+  const products = await getProductsByDateRange({
+    startDate: date.startOf("month"),
+    endDate: date.endOf("month"),
+    limit: 10,
+    page: Number(url.searchParams.get("page")) || 1,
+  });
+  const totalPages = await getProductPagesByDateRange({
+    startDate: date.startOf("month"),
+    endDate: date.endOf("month"),
+  });
   return {
     ...parsedData,
+    products,
+    totalPages,
   };
 };
 
@@ -108,19 +122,19 @@ export default function MonthlyLeaderboardsPage({
         )}
       </div>
       <div className="space-y-5 w-full max-w-screen-md mx-auto">
-        {Array.from({ length: 11 }, (_, index) => (
+        {loaderData.products.map((product) => (
           <ProductCard
-            key={index}
-            id={`product-${index}`}
-            name={`Product ${index + 1}`}
-            description={`Description for product ${index + 1}`}
-            commentCount={Math.floor(Math.random() * 100)}
-            viewCount={Math.floor(Math.random() * 1000)}
-            upvoteCount={Math.floor(Math.random() * 500)}
+            key={product.product_id.toString()}
+            id={product.product_id.toString()}
+            name={product.name}
+            description={product.description}
+            commentCount={product.reviews}
+            viewCount={product.views}
+            upvoteCount={product.upvotes}
           />
         ))}
       </div>
-      <ProductPagination totalPages={10} />
+      <ProductPagination totalPages={loaderData.totalPages} />
     </div>
   );
 }

--- a/app/features/products/pages/weekly-leaderboards-page.tsx
+++ b/app/features/products/pages/weekly-leaderboards-page.tsx
@@ -5,6 +5,8 @@ import { Hero } from "~/common/components/hero";
 import ProductPagination from "~/common/components/pagination";
 import { Button } from "~/common/components/ui/button";
 import { ProductCard } from "../components/product-card";
+import { PAGE_SIZE } from "../constants";
+import { getProductPagesByDateRange, getProductsByDateRange } from "../queries";
 import type { Route } from "./+types/weekly-leaderboards-page";
 
 const paramsSchema = z.object({
@@ -29,7 +31,7 @@ export const meta: Route.MetaFunction = ({ params }) => {
   ];
 };
 
-export const loader = ({ params }: Route.LoaderArgs) => {
+export const loader = async ({ params, request }: Route.LoaderArgs) => {
   const { success, data: parsedData } = paramsSchema.safeParse(params);
 
   if (!success) {
@@ -58,8 +60,21 @@ export const loader = ({ params }: Route.LoaderArgs) => {
     );
   }
 
+  const url = new URL(request.url);
+  const products = await getProductsByDateRange({
+    startDate: date.startOf("week"),
+    endDate: date.endOf("week"),
+    limit: PAGE_SIZE,
+    page: Number(url.searchParams.get("page")) || 1,
+  });
+  const totalPages = await getProductPagesByDateRange({
+    startDate: date.startOf("week"),
+    endDate: date.endOf("week"),
+  });
   return {
     ...parsedData,
+    products,
+    totalPages,
   };
 };
 
@@ -102,19 +117,19 @@ export default function WeeklyLeaderboardsPage({
         )}
       </div>
       <div className="space-y-5 w-full max-w-screen-md mx-auto">
-        {Array.from({ length: 11 }, (_, index) => (
+        {loaderData.products.map((product) => (
           <ProductCard
-            key={index}
-            id={`product-${index}`}
-            name={`Product ${index + 1}`}
-            description={`Description for product ${index + 1}`}
-            commentCount={Math.floor(Math.random() * 100)}
-            viewCount={Math.floor(Math.random() * 1000)}
-            upvoteCount={Math.floor(Math.random() * 500)}
+            key={product.product_id.toString()}
+            id={product.product_id.toString()}
+            name={product.name}
+            description={product.description}
+            commentCount={product.reviews}
+            viewCount={product.views}
+            upvoteCount={product.upvotes}
           />
         ))}
       </div>
-      <ProductPagination totalPages={10} />
+      <ProductPagination totalPages={loaderData.totalPages} />
     </div>
   );
 }

--- a/app/features/products/pages/yearly-leaderboards-page.tsx
+++ b/app/features/products/pages/yearly-leaderboards-page.tsx
@@ -5,6 +5,8 @@ import { Hero } from "~/common/components/hero";
 import ProductPagination from "~/common/components/pagination";
 import { Button } from "~/common/components/ui/button";
 import { ProductCard } from "../components/product-card";
+import { PAGE_SIZE } from "../constants";
+import { getProductPagesByDateRange, getProductsByDateRange } from "../queries";
 import type { Route } from "./+types/yearly-leaderboards-page";
 
 const paramsSchema = z.object({
@@ -25,7 +27,7 @@ export const meta: Route.MetaFunction = ({ params }) => {
   ];
 };
 
-export const loader = ({ params }: Route.LoaderArgs) => {
+export const loader = async ({ params, request }: Route.LoaderArgs) => {
   const { success, data: parsedData } = paramsSchema.safeParse(params);
 
   if (!success) {
@@ -53,8 +55,21 @@ export const loader = ({ params }: Route.LoaderArgs) => {
     );
   }
 
+  const url = new URL(request.url);
+  const products = await getProductsByDateRange({
+    startDate: date.startOf("year"),
+    endDate: date.endOf("year"),
+    limit: PAGE_SIZE,
+    page: Number(url.searchParams.get("page")) || 1,
+  });
+  const totalPages = await getProductPagesByDateRange({
+    startDate: date.startOf("year"),
+    endDate: date.endOf("year"),
+  });
   return {
     ...parsedData,
+    products,
+    totalPages,
   };
 };
 
@@ -91,19 +106,19 @@ export default function YearlyLeaderboardsPage({
         )}
       </div>
       <div className="space-y-5 w-full max-w-screen-md mx-auto">
-        {Array.from({ length: 11 }, (_, index) => (
+        {loaderData.products.map((product) => (
           <ProductCard
-            key={index}
-            id={`product-${index}`}
-            name={`Product ${index + 1}`}
-            description={`Description for product ${index + 1}`}
-            commentCount={Math.floor(Math.random() * 100)}
-            viewCount={Math.floor(Math.random() * 1000)}
-            upvoteCount={Math.floor(Math.random() * 500)}
+            key={product.product_id.toString()}
+            id={product.product_id.toString()}
+            name={product.name}
+            description={product.description}
+            commentCount={product.reviews}
+            viewCount={product.views}
+            upvoteCount={product.upvotes}
           />
         ))}
       </div>
-      <ProductPagination totalPages={10} />
+      <ProductPagination totalPages={loaderData.totalPages} />
     </div>
   );
 }

--- a/app/features/products/queries.ts
+++ b/app/features/products/queries.ts
@@ -1,14 +1,17 @@
 import type { DateTime } from "luxon";
 import client from "~/supa-client";
+import { PAGE_SIZE } from "./constants";
 
 export const getProductsByDateRange = async ({
   startDate,
   endDate,
   limit,
+  page = 1,
 }: {
   startDate: DateTime;
   endDate: DateTime;
   limit: number;
+  page: number;
 }) => {
   const { data, error } = await client
     .from("products")
@@ -24,8 +27,26 @@ export const getProductsByDateRange = async ({
     )
     .gte("created_at", startDate.toISO())
     .lte("created_at", endDate.toISO())
-    .limit(limit)
-    .order("created_at", { ascending: false });
+    .order("stats->>upvotes", { ascending: false })
+    .range((page - 1) * PAGE_SIZE, page * PAGE_SIZE - 1);
+
   if (error) throw new Error(error.message);
   return data;
+};
+
+export const getProductPagesByDateRange = async ({
+  startDate,
+  endDate,
+}: {
+  startDate: DateTime;
+  endDate: DateTime;
+}) => {
+  const { count, error } = await client
+    .from("products")
+    .select(`*`, { count: "exact", head: true })
+    .gte("created_at", startDate.toISO())
+    .lte("created_at", endDate.toISO());
+  if (error) throw new Error(error.message);
+  if (!count) return 1;
+  return Math.ceil(count / PAGE_SIZE);
 };

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -12,26 +12,28 @@ export default [
     index("features/products/pages/products-page.tsx"),
     ...prefix("/leaderboards", [
       index("features/products/pages/leaderboards-page.tsx"),
-      route(
-        "/yearly/:year",
-        "features/products/pages/yearly-leaderboards-page.tsx"
-      ),
-      route(
-        "/monthly/:year/:month",
-        "features/products/pages/monthly-leaderboards-page.tsx"
-      ),
-      route(
-        "/weekly/:year/:week",
-        "features/products/pages/weekly-leaderboards-page.tsx"
-      ),
-      route(
-        "/daily/:year/:month/:day",
-        "features/products/pages/daily-leaderboards-page.tsx"
-      ),
-      route(
-        "/:period",
-        "features/products/pages/leaderboards-redirection-page.tsx"
-      ),
+      layout("features/products/layouts/leaderboard-layout.tsx", [
+        route(
+          "/yearly/:year",
+          "features/products/pages/yearly-leaderboards-page.tsx"
+        ),
+        route(
+          "/monthly/:year/:month",
+          "features/products/pages/monthly-leaderboards-page.tsx"
+        ),
+        route(
+          "/weekly/:year/:week",
+          "features/products/pages/weekly-leaderboards-page.tsx"
+        ),
+        route(
+          "/daily/:year/:month/:day",
+          "features/products/pages/daily-leaderboards-page.tsx"
+        ),
+        route(
+          "/:period",
+          "features/products/pages/leaderboards-redirection-page.tsx"
+        ),
+      ]),
     ]),
     ...prefix("/categories", [
       index("features/products/pages/categories-page.tsx"),


### PR DESCRIPTION
- daily-leaderboards-page와 monthly-leaderboards-page의 loader를 비동기로 변경하여 페이지 쿼리 파라미터에 따른 제품 목록과 총 페이지 수를 가져오도록 수정  
- ProductCard 렌더링 시 더미 데이터 대신 실제 API에서 받아온 제품 데이터를 사용  
- ProductPagination 컴포넌트에 동적으로 계산된 총 페이지 수 전달  
- 날짜 비교 및 현재 시간 처리 시 Asia/Seoul 타임존을 명시적으로 설정하여 시간대 문제를 방지  
- leaderboards-page에서 getProductsByDateRange 호출 시 page 파라미터 기본값 1 추가  
- 전반적으로 페이징 지원과 정확한 데이터 로딩을 위해 API 호출 로직 개선