### PR TITLE
fix: 페이지네이션 관련 불필요한 page 파라미터 제거 및 수정

### DIFF
--- a/app/common/pages/home-page.tsx
+++ b/app/common/pages/home-page.tsx
@@ -26,7 +26,6 @@ export const loader = async () => {
     startDate: DateTime.now().startOf("day"),
     endDate: DateTime.now().endOf("day"),
     limit: 8,
-    page: 1,
   });
   return { dailyProducts };
 };

--- a/app/features/products/pages/leaderboards-page.tsx
+++ b/app/features/products/pages/leaderboards-page.tsx
@@ -20,25 +20,21 @@ export const loader = async () => {
         startDate: DateTime.now().startOf("day"),
         endDate: DateTime.now().endOf("day"),
         limit: 8,
-        page: 1,
       }),
       getProductsByDateRange({
         startDate: DateTime.now().startOf("week"),
         endDate: DateTime.now().endOf("week"),
         limit: 8,
-        page: 1,
       }),
       getProductsByDateRange({
         startDate: DateTime.now().startOf("month"),
         endDate: DateTime.now().endOf("month"),
         limit: 8,
-        page: 1,
       }),
       getProductsByDateRange({
         startDate: DateTime.now().startOf("year"),
         endDate: DateTime.now().endOf("year"),
         limit: 8,
-        page: 1,
       }),
     ]);
 

--- a/app/features/products/pages/monthly-leaderboards-page.tsx
+++ b/app/features/products/pages/monthly-leaderboards-page.tsx
@@ -7,6 +7,7 @@ import { Button } from "~/common/components/ui/button";
 import { ProductCard } from "../components/product-card";
 import { getProductPagesByDateRange, getProductsByDateRange } from "../queries";
 import type { Route } from "./+types/monthly-leaderboards-page";
+import { PAGE_SIZE } from "../constants";
 
 const paramsSchema = z.object({
   year: z.coerce.number(),
@@ -62,7 +63,7 @@ export const loader = async ({ params, request }: Route.LoaderArgs) => {
   const products = await getProductsByDateRange({
     startDate: date.startOf("month"),
     endDate: date.endOf("month"),
-    limit: 10,
+    limit: PAGE_SIZE,
     page: Number(url.searchParams.get("page")) || 1,
   });
   const totalPages = await getProductPagesByDateRange({

--- a/app/features/products/queries.ts
+++ b/app/features/products/queries.ts
@@ -11,7 +11,7 @@ export const getProductsByDateRange = async ({
   startDate: DateTime;
   endDate: DateTime;
   limit: number;
-  page: number;
+  page?: number;
 }) => {
   const { data, error } = await client
     .from("products")
@@ -28,7 +28,7 @@ export const getProductsByDateRange = async ({
     .gte("created_at", startDate.toISO())
     .lte("created_at", endDate.toISO())
     .order("stats->>upvotes", { ascending: false })
-    .range((page - 1) * PAGE_SIZE, page * PAGE_SIZE - 1);
+    .range((page - 1) * limit, page * limit - 1);
 
   if (error) throw new Error(error.message);
   return data;


### PR DESCRIPTION
- home-page와 leaderboards-page에서 불필요한 page 파라미터 제거  
- queries.ts에서 page를 선택적(optional)으로 수정  
- limit 값을 이용해 범위를 계산하도록 페이지네이션 로직 개선  
- monthly-leaderboards-page에서 하드코딩된 limit 값을 PAGE_SIZE 상수로 대체  
- 코드 중복과 하드코딩 감소, 페이지네이션 로직의 유연성 향상