### PR TITLE
feat: 홈 페이지에 최신 커뮤니티 게시물 추가

### DIFF
--- a/app/common/pages/home-page.tsx
+++ b/app/common/pages/home-page.tsx
@@ -14,6 +14,7 @@ import { RetroGrid } from "~/common/components/magicui/retro-grid";
 import type { Route } from "./+types/home-page";
 import { getProductsByDateRange } from "~/features/products/queries";
 import { DateTime } from "luxon";
+import { getPosts } from "~/features/community/queries";
 export const meta: MetaFunction = () => {
   return [
     { title: "Home | wemake" },
@@ -27,7 +28,11 @@ export const loader = async () => {
     endDate: DateTime.now().endOf("day"),
     limit: 8,
   });
-  return { dailyProducts };
+  const posts = await getPosts({
+    limit: 8,
+    sorting: "newest",
+  });
+  return { dailyProducts, posts };
 };
 
 export default function HomePage({ loaderData }: Route.ComponentProps) {
@@ -179,41 +184,41 @@ export default function HomePage({ loaderData }: Route.ComponentProps) {
           </div>
           <div className="relative col-span-2 flex flex-col md:[perspective:500px] md:pb-40 overflow-hidden md:*:[transform:translateZ(-0px)_rotateY(-20deg)_rotateZ(10deg)]">
             <Marquee pauseOnHover className="[--duration:20s]">
-              {Array.from({ length: 3 }, (_, index) => (
+              {loaderData.posts.map((post) => (
                 <PostCard
-                  key={index}
-                  id={index}
-                  title={`Post ${index + 1}`}
-                  author="Harry"
-                  authorAvatarUrl="https://github.com/apple.png"
-                  category="Productivity"
-                  postedAt="12 hours ago"
+                  key={post.post_id}
+                  id={post.post_id}
+                  title={post.title}
+                  author={post.author}
+                  authorAvatarUrl={post.author_avatar}
+                  category={post.topic}
+                  postedAt={post.created_at}
                 />
               ))}
             </Marquee>
             <Marquee reverse pauseOnHover className="[--duration:20s]">
-              {Array.from({ length: 3 }, (_, index) => (
+              {loaderData.posts.map((post) => (
                 <PostCard
-                  key={index}
-                  id={index}
-                  title={`Post ${index + 1}`}
-                  author="Harry"
-                  authorAvatarUrl="https://github.com/apple.png"
-                  category="Productivity"
-                  postedAt="12 hours ago"
+                  key={post.post_id}
+                  id={post.post_id}
+                  title={post.title}
+                  author={post.author}
+                  authorAvatarUrl={post.author_avatar}
+                  category={post.topic}
+                  postedAt={post.created_at}
                 />
               ))}
             </Marquee>
             <Marquee pauseOnHover className="[--duration:20s]">
-              {Array.from({ length: 3 }, (_, index) => (
+              {loaderData.posts.map((post) => (
                 <PostCard
-                  key={index}
-                  id={index}
-                  title={`Post ${index + 1}`}
-                  author="Harry"
-                  authorAvatarUrl="https://github.com/apple.png"
-                  category="Productivity"
-                  postedAt="12 hours ago"
+                  key={post.post_id}
+                  id={post.post_id}
+                  title={post.title}
+                  author={post.author}
+                  authorAvatarUrl={post.author_avatar}
+                  category={post.topic}
+                  postedAt={post.created_at}
                 />
               ))}
             </Marquee>

--- a/app/sql/views/community-post-list-view.sql
+++ b/app/sql/views/community-post-list-view.sql
@@ -1,4 +1,4 @@
-CREATE VIEW community_post_list_view AS
+CREATE OR REPLACE VIEW community_post_list_view AS
 SELECT
     posts.post_id,
     posts.title,
@@ -7,9 +7,11 @@ SELECT
     profiles.name as author,
     profiles.avatar as author_avatar,
     profiles.username as author_username,
-    COUNT(post_upvotes.post_id) as upvotes
+    posts.upvotes,
+    topics.slug as topic_slug
 FROM posts
 INNER JOIN topics USING (topic_id)
-INNER JOIN profiles USING (profile_id)
-LEFT JOIN post_upvotes USING (post_id)
-GROUP BY posts.post_id, topics.name, profiles.name, profiles.avatar, profiles.username;
+INNER JOIN profiles USING (profile_id);
+
+
+select * from community_post_list_view;

--- a/database.types.ts
+++ b/database.types.ts
@@ -446,6 +446,7 @@ export type Database = {
           title: string
           topic_id: number
           updated_at: string
+          upvotes: number | null
         }
         Insert: {
           content: string
@@ -455,6 +456,7 @@ export type Database = {
           title: string
           topic_id: number
           updated_at?: string
+          upvotes?: number | null
         }
         Update: {
           content?: string
@@ -464,6 +466,7 @@ export type Database = {
           title?: string
           topic_id?: number
           updated_at?: string
+          upvotes?: number | null
         }
         Relationships: [
           {
@@ -730,6 +733,7 @@ export type Database = {
           post_id: number | null
           title: string | null
           topic: string | null
+          topic_slug: string | null
           upvotes: number | null
         }
         Relationships: []


### PR DESCRIPTION
- 홈 페이지에 최신 커뮤니티 게시물 8개를 마퀴 형태로 표시하는 기능 추가  
- 커뮤니티 쿼리의 getPosts 함수 확장  
- 정렬, 기간, 키워드, 주제별 필터링 기능 개선  
- 사용자에게 다양한 최신 정보 제공 강화