### PR TITLE
feat: 아이디어 페이지 및 카드에 데이터 로딩과 상대 시간 표시 추가

### DIFF
--- a/app/common/pages/home-page.tsx
+++ b/app/common/pages/home-page.tsx
@@ -15,6 +15,7 @@ import type { Route } from "./+types/home-page";
 import { getProductsByDateRange } from "~/features/products/queries";
 import { DateTime } from "luxon";
 import { getPosts } from "~/features/community/queries";
+import { getGptIdeas } from "~/features/ideas/queries";
 export const meta: MetaFunction = () => {
   return [
     { title: "Home | wemake" },
@@ -32,7 +33,10 @@ export const loader = async () => {
     limit: 8,
     sorting: "newest",
   });
-  return { dailyProducts, posts };
+  const ideas = await getGptIdeas({
+    limit: 8,
+  });
+  return { dailyProducts, posts, ideas };
 };
 
 export default function HomePage({ loaderData }: Route.ComponentProps) {
@@ -102,15 +106,15 @@ export default function HomePage({ loaderData }: Route.ComponentProps) {
             </div>
             <div className="md:absolute w-full flex justify-between md:h-full h-[75vh] top-0 left-0">
               <Marquee pauseOnHover vertical className="[--duration:20s]">
-                {Array.from({ length: 3 }, (_, index) => (
+                {loaderData.ideas.map((idea) => (
                   <IdeaCard
-                    key={index}
-                    id={`idea-${index}`}
-                    title="Personalized Learning Path Generator: An AI-driven platform that creates customized learning paths f..."
-                    viewCount={Math.floor(Math.random() * 1000)}
-                    createdAt="12 hours ago"
-                    likeCount={Math.floor(Math.random() * 100)}
-                    claimed={false}
+                    key={idea.gpt_idea_id}
+                    id={idea.gpt_idea_id}
+                    title={idea.idea}
+                    viewCount={idea.views}
+                    createdAt={idea.created_at}
+                    likeCount={idea.likes}
+                    claimed={idea.is_claimed}
                   />
                 ))}
               </Marquee>
@@ -120,28 +124,28 @@ export default function HomePage({ loaderData }: Route.ComponentProps) {
                 vertical
                 className="[--duration:20s]"
               >
-                {Array.from({ length: 3 }, (_, index) => (
+                {loaderData.ideas.map((idea) => (
                   <IdeaCard
-                    key={index}
-                    id={`idea-${index}`}
-                    title="Smart Meeting Summarizer: An AI tool that joins virtual meetings, records discussions, and generates..."
-                    viewCount={Math.floor(Math.random() * 1000)}
-                    createdAt="12 hours ago"
-                    likeCount={Math.floor(Math.random() * 100)}
-                    claimed={false}
+                    key={idea.gpt_idea_id}
+                    id={idea.gpt_idea_id}
+                    title={idea.idea}
+                    viewCount={idea.views}
+                    createdAt={idea.created_at}
+                    likeCount={idea.likes}
+                    claimed={idea.is_claimed}
                   />
                 ))}
               </Marquee>
               <Marquee pauseOnHover vertical className="[--duration:20s]">
-                {Array.from({ length: 3 }, (_, index) => (
+                {loaderData.ideas.map((idea) => (
                   <IdeaCard
-                    key={index}
-                    id={`idea-${index}`}
-                    title="Personalized Learning Path Generator: An AI-driven platform that creates customized learning paths f..."
-                    viewCount={Math.floor(Math.random() * 1000)}
-                    createdAt="12 hours ago"
-                    likeCount={Math.floor(Math.random() * 100)}
-                    claimed={false}
+                    key={idea.gpt_idea_id}
+                    id={idea.gpt_idea_id}
+                    title={idea.idea}
+                    viewCount={idea.views}
+                    createdAt={idea.created_at}
+                    likeCount={idea.likes}
+                    claimed={idea.is_claimed}
                   />
                 ))}
               </Marquee>
@@ -151,15 +155,15 @@ export default function HomePage({ loaderData }: Route.ComponentProps) {
                 vertical
                 className="[--duration:20s]"
               >
-                {Array.from({ length: 3 }, (_, index) => (
+                {loaderData.ideas.map((idea) => (
                   <IdeaCard
-                    key={index}
-                    id={`idea-${index}`}
-                    title="Smart Meeting Summarizer: An AI tool that joins virtual meetings, records discussions, and generates..."
-                    viewCount={Math.floor(Math.random() * 1000)}
-                    createdAt="12 hours ago"
-                    likeCount={Math.floor(Math.random() * 100)}
-                    claimed={false}
+                    key={idea.gpt_idea_id}
+                    id={idea.gpt_idea_id}
+                    title={idea.idea}
+                    viewCount={idea.views}
+                    createdAt={idea.created_at}
+                    likeCount={idea.likes}
+                    claimed={idea.is_claimed}
                   />
                 ))}
               </Marquee>

--- a/app/features/ideas/components/idea-card.tsx
+++ b/app/features/ideas/components/idea-card.tsx
@@ -1,4 +1,5 @@
 import { DotIcon, EyeIcon, HeartIcon, LockIcon } from "lucide-react";
+import { DateTime } from "luxon";
 import { Link } from "react-router";
 import { Button } from "~/common/components/ui/button";
 import {
@@ -11,7 +12,7 @@ import {
 import { cn } from "~/lib/utils";
 
 interface IdeaCardProps {
-  id: string;
+  id: number;
   title: string;
   viewCount: number;
   createdAt: string;
@@ -50,7 +51,7 @@ export function IdeaCard({
           <span>{viewCount}</span>
         </div>
         <DotIcon className="size-4" />
-        <span>{createdAt}</span>
+        <span>{DateTime.fromISO(createdAt).toRelative()}</span>
       </CardContent>
       <CardFooter className="flex justify-end gap-2">
         <Button variant="outline">

--- a/app/features/ideas/pages/idea-page.tsx
+++ b/app/features/ideas/pages/idea-page.tsx
@@ -2,38 +2,48 @@ import { DotIcon, EyeIcon, HeartIcon } from "lucide-react";
 import { Hero } from "~/common/components/hero";
 import { Button } from "~/common/components/ui/button";
 import type { Route } from "./+types/idea-page";
+import { getGptIdea } from "../queries";
+import { DateTime } from "luxon";
 
-export const meta: Route.MetaFunction = () => {
+export const meta = ({
+  data: {
+    idea: { gpt_idea_id },
+  },
+}: Route.MetaArgs) => {
   return [
     {
-      title: "IdeaGPT | wemake",
+      title: `IdeaGPT #${gpt_idea_id}  | wemake`,
       description: "Find ideas for your next project",
     },
   ];
 };
 
-export default function IdeaPage() {
+export const loader = async ({ params }: Route.LoaderArgs) => {
+  const idea = await getGptIdea({
+    id: Number(params.ideaId),
+  });
+  return { idea };
+};
+
+export default function IdeaPage({ loaderData }: Route.ComponentProps) {
   return (
     <div>
-      <Hero title="IdeaGPT #12312312312" />
+      <Hero title={`IdeaGPT #${loaderData.idea.gpt_idea_id}`} />
       <div className="max-w-screen-sm mx-auto flex flex-col items-center gap-10">
-        <p className="italic text-center">
-          A Startup that creates an AI-powered generated personal trainer,
-          delivering customized fitness recommendations based on the user's
-          goals and preferences and also provides a community for users to
-          connect and share their fitness journey.
-        </p>
+        <p className="italic text-center">{loaderData.idea.idea}</p>
         <div className="flex items-center text-sm">
           <div className="flex items-center gap-1">
             <EyeIcon className="size-4" />
-            <span>123</span>
+            <span>{loaderData.idea.views}</span>
           </div>
           <DotIcon className="size-4" />
-          <span>10 hours ago</span>
+          <span>
+            {DateTime.fromISO(loaderData.idea.created_at).toRelative()}
+          </span>
           <DotIcon className="size-4" />
           <Button variant="outline">
             <HeartIcon className="size-4" />
-            <span>12</span>
+            <span>{loaderData.idea.likes}</span>
           </Button>
         </div>
         <Button size="lg">Claim idea now &rarr;</Button>

--- a/app/features/ideas/pages/ideas-page.tsx
+++ b/app/features/ideas/pages/ideas-page.tsx
@@ -1,6 +1,7 @@
 import { Hero } from "~/common/components/hero";
 import { IdeaCard } from "../components/idea-card";
 import type { Route } from "./+types/ideas-page";
+import { getGptIdeas } from "../queries";
 
 export const meta: Route.MetaFunction = () => {
   return [
@@ -11,20 +12,27 @@ export const meta: Route.MetaFunction = () => {
   ];
 };
 
-export default function IdeasPage() {
+export const loader = async () => {
+  const ideas = await getGptIdeas({
+    limit: 11,
+  });
+  return { ideas };
+};
+
+export default function IdeasPage({ loaderData }: Route.ComponentProps) {
   return (
     <div className="space-y-20">
       <Hero title="IdeasGPT" subtitle="Find ideas for your next project" />
       <div className="grid grid-cols-4 gap-4">
-        {Array.from({ length: 11 }, (_, index) => (
+        {loaderData.ideas.map((idea) => (
           <IdeaCard
-            key={index}
-            id={`idea-${index}`}
-            title="A Startup that creates an AI-powered generated personal trainer, delivering customized fitness recommendations based on the user's goals and preferences."
-            viewCount={Math.floor(Math.random() * 1000)}
-            createdAt="12 hours ago"
-            likeCount={Math.floor(Math.random() * 100)}
-            claimed={index % 2 === 0}
+            key={idea.gpt_idea_id}
+            id={idea.gpt_idea_id}
+            title={idea.idea}
+            viewCount={idea.views}
+            createdAt={idea.created_at}
+            likeCount={idea.likes}
+            claimed={idea.is_claimed}
           />
         ))}
       </div>

--- a/app/features/ideas/queries.ts
+++ b/app/features/ideas/queries.ts
@@ -1,0 +1,24 @@
+import client from "~/supa-client";
+
+export const getGptIdeas = async ({ limit }: { limit: number }) => {
+  const { data, error } = await client
+    .from("gpt_ideas_view")
+    .select("*")
+    .limit(limit);
+  if (error) {
+    throw error;
+  }
+  return data;
+};
+
+export const getGptIdea = async ({ id }: { id: number }) => {
+  const { data, error } = await client
+    .from("gpt_ideas_view")
+    .select("*")
+    .eq("gpt_idea_id", id)
+    .single();
+  if (error) {
+    throw error;
+  }
+  return data;
+};

--- a/app/sql/views/gpt-ideas-view.sql
+++ b/app/sql/views/gpt-ideas-view.sql
@@ -1,0 +1,14 @@
+CREATE OR REPLACE VIEW gpt_ideas_view AS
+SELECT
+    gpt_ideas.gpt_idea_id,
+    gpt_ideas.idea,
+    gpt_ideas.views,
+    CASE WHEN gpt_ideas.claimed_at IS NULL THEN FALSE ELSE TRUE END AS is_claimed,
+    gpt_ideas.created_at,
+    COUNT(gpt_ideas_likes.gpt_idea_id) AS likes
+FROM gpt_ideas
+LEFT JOIN gpt_ideas_likes USING (gpt_idea_id)
+GROUP BY gpt_ideas.gpt_idea_id;
+
+
+select * from gpt_ideas_view;

--- a/app/supa-client.ts
+++ b/app/supa-client.ts
@@ -16,6 +16,11 @@ type Database = MergeDeep<
             string | null
           >;
         };
+        gpt_ideas_view: {
+          Row: SetNonNullable<
+            SupabaseDatabase["public"]["Views"]["gpt_ideas_view"]["Row"]
+          >;
+        };
       };
     };
   }

--- a/database.types.ts
+++ b/database.types.ts
@@ -123,6 +123,13 @@ export type Database = {
             referencedColumns: ["gpt_idea_id"]
           },
           {
+            foreignKeyName: "gpt_ideas_likes_gpt_idea_id_gpt_ideas_gpt_idea_id_fk"
+            columns: ["gpt_idea_id"]
+            isOneToOne: false
+            referencedRelation: "gpt_ideas_view"
+            referencedColumns: ["gpt_idea_id"]
+          },
+          {
             foreignKeyName: "gpt_ideas_likes_profile_id_profiles_profile_id_fk"
             columns: ["profile_id"]
             isOneToOne: false
@@ -735,6 +742,17 @@ export type Database = {
           topic: string | null
           topic_slug: string | null
           upvotes: number | null
+        }
+        Relationships: []
+      }
+      gpt_ideas_view: {
+        Row: {
+          created_at: string | null
+          gpt_idea_id: number | null
+          idea: string | null
+          is_claimed: boolean | null
+          likes: number | null
+          views: number | null
         }
         Relationships: []
       }


### PR DESCRIPTION
- 아이디어 카드 컴포넌트에서 createdAt을 luxon의 toRelative로 상대 시간 표시
- id 타입을 string에서 number로 변경하여 일관성 유지
- 아이디어 페이지와 아이디어 목록 페이지에 loader 함수 추가, API에서 실제 데이터 로딩
- 페이지 타이틀과 내용, 조회수, 좋아요 수를 동적 데이터로 렌더링하도록 수정
- 데이터베이스 타입에 gpt_ideas_view 테이블 및 관계 추가로 조회수, 좋아요 등 확장 지원
- 사용자에게 더 직관적인 시간 정보와 실제 데이터를 보여주기 위해 변경