### PR TITLE
feat: 카테고리 페이지 데이터 로딩 및 키 처리 개선

### DIFF
--- a/app/features/jobs/components/job-card.tsx
+++ b/app/features/jobs/components/job-card.tsx
@@ -53,8 +53,12 @@ export function JobCard({
           <CardTitle>{title}</CardTitle>
         </CardHeader>
         <CardContent>
-          <Badge variant="outline">{type}</Badge>
-          <Badge variant="outline">{positionLocation}</Badge>
+          <Badge variant="outline" className="capitalize">
+            {type}
+          </Badge>
+          <Badge variant="outline" className="capitalize">
+            {positionLocation}
+          </Badge>
         </CardContent>
         <CardFooter className="flex justify-between">
           <div className="flex flex-col">

--- a/app/features/products/components/category-card.tsx
+++ b/app/features/products/components/category-card.tsx
@@ -8,7 +8,7 @@ import {
 } from "~/common/components/ui/card";
 
 interface CategoryCardProps {
-  id: string;
+  id: number;
   name: string;
   description: string;
 }

--- a/app/features/products/components/product-card.tsx
+++ b/app/features/products/components/product-card.tsx
@@ -10,7 +10,7 @@ import {
 } from "~/common/components/ui/card";
 
 interface ProductCardProps {
-  id: string;
+  id: number;
   name: string;
   description: string;
   commentCount: string;

--- a/app/features/products/pages/categories-page.tsx
+++ b/app/features/products/pages/categories-page.tsx
@@ -1,6 +1,7 @@
 import { Hero } from "~/common/components/hero";
 import { CategoryCard } from "../components/category-card";
 import type { Route } from "./+types/categories-page";
+import { getCategories } from "../queries";
 
 export const meta: Route.MetaFunction = () => {
   return [
@@ -9,17 +10,22 @@ export const meta: Route.MetaFunction = () => {
   ];
 };
 
-export default function CategoriesPage() {
+export const loader = async () => {
+  const categories = await getCategories();
+  return { categories };
+};
+
+export default function CategoriesPage({ loaderData }: Route.ComponentProps) {
   return (
     <div className="space-y-10">
       <Hero title="Categories" subtitle="Browse products by category" />
       <div className="grid grid-cols-4 gap-10">
-        {Array.from({ length: 10 }).map((_, index) => (
+        {loaderData.categories.map((category) => (
           <CategoryCard
-            key={index}
-            id={`categoryId-${index}`}
-            name={`Category Name ${index}`}
-            description={`Category Description ${index}`}
+            key={category.category_id}
+            id={category.category_id}
+            name={category.name}
+            description={category.description}
           />
         ))}
       </div>

--- a/app/features/products/pages/category-page.tsx
+++ b/app/features/products/pages/category-page.tsx
@@ -2,38 +2,61 @@ import { Hero } from "~/common/components/hero";
 import ProductPagination from "~/common/components/pagination";
 import { ProductCard } from "../components/product-card";
 import type { Route } from "./+types/category-page";
+import {
+  getCategory,
+  getProductPagesByCategory,
+  getProductsByCategory,
+} from "../queries";
+import { PAGE_SIZE } from "../constants";
 
-export const meta: Route.MetaFunction = ({ params }: Route.MetaArgs) => {
+export const meta: Route.MetaFunction = ({ data }: Route.MetaArgs) => {
   return [
-    { title: "Developer Tools | wemake" },
+    { title: `${data.category.name} | wemake` },
     {
       name: "description",
-      content: "Tools for developers to build products faster",
+      content: data.category.description,
     },
   ];
 };
 
-export default function CategoryPage() {
+export const loader = async ({ params }: Route.LoaderArgs) => {
+  const [products, totalPages, category] = await Promise.all([
+    getProductsByCategory({
+      categoryId: Number(params.categoryId),
+      limit: PAGE_SIZE,
+    }),
+    getProductPagesByCategory({
+      categoryId: Number(params.categoryId),
+    }),
+    getCategory({
+      categoryId: Number(params.categoryId),
+    }),
+  ]);
+
+  return { products, totalPages, category };
+};
+
+export default function CategoryPage({ loaderData }: Route.ComponentProps) {
   return (
     <div className="space-y-10">
       <Hero
-        title="Developer Tools"
-        subtitle="Tools for developers to build products faster"
+        title={loaderData.category.name}
+        subtitle={loaderData.category.description}
       />
       <div className="space-y-5 w-full max-w-screen-md mx-auto">
-        {Array.from({ length: 11 }, (_, index) => (
+        {loaderData.products.map((product) => (
           <ProductCard
-            key={index}
-            id={`product-${index}`}
-            name={`Product ${index + 1}`}
-            description={`Description for product ${index + 1}`}
-            commentCount={Math.floor(Math.random() * 100)}
-            viewCount={Math.floor(Math.random() * 1000)}
-            upvoteCount={Math.floor(Math.random() * 500)}
+            key={product.product_id}
+            id={product.product_id}
+            name={product.name}
+            description={product.description}
+            commentCount={product.reviews}
+            viewCount={product.views}
+            upvoteCount={product.upvotes}
           />
         ))}
       </div>
-      <ProductPagination totalPages={10} />
+      <ProductPagination totalPages={loaderData.totalPages} />
     </div>
   );
 }

--- a/app/features/products/pages/daily-leaderboards-page.tsx
+++ b/app/features/products/pages/daily-leaderboards-page.tsx
@@ -115,8 +115,8 @@ export default function DailyLeaderboardsPage({
       <div className="space-y-5 w-full max-w-screen-md mx-auto">
         {loaderData.products.map((product) => (
           <ProductCard
-            key={product.product_id.toString()}
-            id={product.product_id.toString()}
+            key={product.product_id}
+            id={product.product_id}
             name={product.name}
             description={product.description}
             commentCount={product.reviews}

--- a/app/features/products/pages/leaderboards-page.tsx
+++ b/app/features/products/pages/leaderboards-page.tsx
@@ -59,8 +59,8 @@ export default function LeaderboardsPage({ loaderData }: Route.ComponentProps) {
 
         {loaderData.dailyProducts.map((product) => (
           <ProductCard
-            key={product.product_id.toString()}
-            id={product.product_id.toString()}
+            key={product.product_id}
+            id={product.product_id}
             name={product.name}
             description={product.description}
             commentCount={product.reviews}
@@ -86,8 +86,8 @@ export default function LeaderboardsPage({ loaderData }: Route.ComponentProps) {
 
         {loaderData.weeklyProducts.map((product) => (
           <ProductCard
-            key={product.product_id.toString()}
-            id={product.product_id.toString()}
+            key={product.product_id}
+            id={product.product_id}
             name={product.name}
             description={product.description}
             commentCount={product.reviews}
@@ -113,8 +113,8 @@ export default function LeaderboardsPage({ loaderData }: Route.ComponentProps) {
 
         {loaderData.monthlyProducts.map((product) => (
           <ProductCard
-            key={product.product_id.toString()}
-            id={product.product_id.toString()}
+            key={product.product_id}
+            id={product.product_id}
             name={product.name}
             description={product.description}
             commentCount={product.reviews}
@@ -140,8 +140,8 @@ export default function LeaderboardsPage({ loaderData }: Route.ComponentProps) {
 
         {loaderData.yearlyProducts.map((product) => (
           <ProductCard
-            key={product.product_id.toString()}
-            id={product.product_id.toString()}
+            key={product.product_id}
+            id={product.product_id}
             name={product.name}
             description={product.description}
             commentCount={product.reviews}

--- a/app/features/products/pages/monthly-leaderboards-page.tsx
+++ b/app/features/products/pages/monthly-leaderboards-page.tsx
@@ -125,8 +125,8 @@ export default function MonthlyLeaderboardsPage({
       <div className="space-y-5 w-full max-w-screen-md mx-auto">
         {loaderData.products.map((product) => (
           <ProductCard
-            key={product.product_id.toString()}
-            id={product.product_id.toString()}
+            key={product.product_id}
+            id={product.product_id}
             name={product.name}
             description={product.description}
             commentCount={product.reviews}

--- a/app/features/products/pages/weekly-leaderboards-page.tsx
+++ b/app/features/products/pages/weekly-leaderboards-page.tsx
@@ -119,8 +119,8 @@ export default function WeeklyLeaderboardsPage({
       <div className="space-y-5 w-full max-w-screen-md mx-auto">
         {loaderData.products.map((product) => (
           <ProductCard
-            key={product.product_id.toString()}
-            id={product.product_id.toString()}
+            key={product.product_id}
+            id={product.product_id}
             name={product.name}
             description={product.description}
             commentCount={product.reviews}

--- a/app/features/products/pages/yearly-leaderboards-page.tsx
+++ b/app/features/products/pages/yearly-leaderboards-page.tsx
@@ -108,8 +108,8 @@ export default function YearlyLeaderboardsPage({
       <div className="space-y-5 w-full max-w-screen-md mx-auto">
         {loaderData.products.map((product) => (
           <ProductCard
-            key={product.product_id.toString()}
-            id={product.product_id.toString()}
+            key={product.product_id}
+            id={product.product_id}
             name={product.name}
             description={product.description}
             commentCount={product.reviews}

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -37,7 +37,7 @@ export default [
     ]),
     ...prefix("/categories", [
       index("features/products/pages/categories-page.tsx"),
-      route("/:category", "features/products/pages/category-page.tsx"),
+      route("/:categoryId", "features/products/pages/category-page.tsx"),
     ]),
     route("/search", "features/products/pages/search-page.tsx"),
     route("/submit", "features/products/pages/submit-product-page.tsx"),


### PR DESCRIPTION
- 카테리 페이지에서 get 쿼리를 사용 실제 데이터를 로드하도록 loader 함수 추가  
- 하드코딩된 더미 데이터 대신 API에서 받아온 카테고리 정보를 렌더링  
- product_id를 문자열로 변환하지 않고 고유 키로 직접 사용하도록 수정  
- job-card 컴포넌트의 Badge에 capitalize 클래스 추가해 스타일 개선  
- category-page 메타 정보에 동적 카테고리 이름과 설명 반영  
- category-page loader에서 카테고리 및 제품 데이터를 API로부터 병렬로 받아오도록 변경