### PR TITLE
fix: 내비게이션 링크 쿼리 파라미터 수정

### DIFF
--- a/app/common/components/navigation.tsx
+++ b/app/common/components/navigation.tsx
@@ -105,12 +105,12 @@ const menus = [
       {
         name: "Top Posts",
         description: "See the top posts in our community",
-        to: "/community?sort=top",
+        to: "/community?sorting=popular",
       },
       {
         name: "New Posts",
         description: "See the new posts in our community",
-        to: "/community?sort=new",
+        to: "/community?sorting=newest",
       },
       {
         name: "Create a Post",


### PR DESCRIPTION
- 커뮤니티 내비게이션의 정렬 쿼리 파라미터 키를 'sort'에서 'sorting'으로 변경  
- 인기 게시물과 최신 게시물의 값도 각각 'popular'와 'newest'로 업데이트  
- 링크가 올바르게 작동하도록 수정하여 사용자 경험 향상