### PR TITLE
feat: 제품 개요 페이지에 동적 데이터 로딩 추가

### DIFF
--- a/app/features/products/layouts/product-overview-layout.tsx
+++ b/app/features/products/layouts/product-overview-layout.tsx
@@ -1,24 +1,66 @@
 import { ChevronUpIcon, StarIcon } from "lucide-react";
-import { NavLink, Outlet } from "react-router";
+import { data, NavLink, Outlet } from "react-router";
 import { Button, buttonVariants } from "~/common/components/ui/button";
 import { cn } from "~/lib/utils";
+import type { Route } from "./+types/product-overview-layout";
+import { getProductById } from "../queries";
+import { z } from "zod";
 
-export default function ProductOverviewLayout() {
+export function meta({ data }: Route.MetaArgs) {
+  return [
+    { title: `${data.product.name} Overview | wemake` },
+    { name: "description", content: "View product details and information" },
+  ];
+}
+
+const paramsSchema = z.object({
+  productId: z.coerce.number(),
+});
+
+export const loader = async ({
+  params,
+}: Route.LoaderArgs & { params: { productId: string } }) => {
+  const { success, data: parsedData } = paramsSchema.safeParse(params);
+
+  if (!success) {
+    throw data(
+      { error_code: "invalid params", message: "Invalid params" },
+      { status: 400 }
+    );
+  }
+
+  const product = await getProductById(parsedData.productId);
+  return { product };
+};
+
+export default function ProductOverviewLayout({
+  loaderData,
+}: Route.ComponentProps) {
   return (
     <div className="space-y-10">
       <div className="flex justify-between">
         <div className="flex gap-10">
           <div className="size-40 rounded-xl shadow-xl bg-primary/50" />
           <div>
-            <h1 className="text-5xl font-bold">Product Name</h1>
-            <p className="text-2xl font-light">Product Description</p>
+            <h1 className="text-5xl font-bold">{loaderData.product.name}</h1>
+            <p className="text-2xl font-light">{loaderData.product.tagline}</p>
             <div className="mt-5 flex items-center gap-2">
               <div className="flex text-yellow-400">
                 {Array.from({ length: 5 }).map((_, index) => (
-                  <StarIcon className="size-4" fill="currentColor" />
+                  <StarIcon
+                    key={index}
+                    className="size-4"
+                    fill={
+                      index < Math.floor(loaderData.product.average_rating)
+                        ? "currentColor"
+                        : "none"
+                    }
+                  />
                 ))}
               </div>
-              <span className="text-muted-foreground">100 reviews</span>
+              <span className="text-muted-foreground">
+                {loaderData.product.reviews} reviews
+              </span>
             </div>
           </div>
         </div>
@@ -32,7 +74,7 @@ export default function ProductOverviewLayout() {
           </Button>
           <Button size="lg" className="text-lg h-14 px-10">
             <ChevronUpIcon className="size-4" />
-            Upvote (100)
+            Upvote ({loaderData.product.upvotes})
           </Button>
         </div>
       </div>
@@ -44,7 +86,7 @@ export default function ProductOverviewLayout() {
               isActive && "bg-accent text-foreground"
             )
           }
-          to={`/products/1/overview`}
+          to={`/products/${loaderData.product.product_id}/overview`}
         >
           Overview
         </NavLink>
@@ -55,13 +97,19 @@ export default function ProductOverviewLayout() {
               isActive && "bg-accent text-foreground"
             )
           }
-          to={`/products/1/reviews`}
+          to={`/products/${loaderData.product.product_id}/reviews`}
         >
           Reviews
         </NavLink>
       </div>
       <div>
-        <Outlet />
+        <Outlet
+          context={{
+            product_id: loaderData.product.product_id,
+            description: loaderData.product.description,
+            how_it_works: loaderData.product.how_it_works,
+          }}
+        />
       </div>
     </div>
   );

--- a/app/features/products/pages/product-overview-page.tsx
+++ b/app/features/products/pages/product-overview-page.tsx
@@ -1,26 +1,20 @@
-export function meta() {
-  return [
-    { title: "Product Overview | wemake" },
-    { name: "description", content: "View product details and information" },
-  ];
-}
+import { useOutletContext } from "react-router";
 
 export default function ProductOverviewPage() {
+  const { description, how_it_works } = useOutletContext<{
+    description: string;
+    how_it_works: string;
+  }>();
+
   return (
     <div className="space-y-10">
       <div className="space-y-1">
         <h3 className="text-lg font-bold">What is this product?</h3>
-        <p className="text-muted-foreground">
-          Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam,
-          quos.
-        </p>
+        <p className="text-muted-foreground">{description}</p>
       </div>
       <div className="space-y-1">
         <h3 className="text-lg font-bold">How does it work?</h3>
-        <p className="text-muted-foreground">
-          Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam,
-          quos.
-        </p>
+        <p className="text-muted-foreground">{how_it_works}</p>
       </div>
     </div>
   );

--- a/app/features/products/queries.ts
+++ b/app/features/products/queries.ts
@@ -144,3 +144,14 @@ export const getProductPagesBySearch = async ({ query }: { query: string }) => {
   if (!count) return 1;
   return Math.ceil(count / PAGE_SIZE);
 };
+
+export const getProductById = async (productId: number) => {
+  const { data, error } = await client
+    .from("product_overview_view")
+    .select("*")
+    .eq("product_id", productId)
+    .single();
+
+  if (error) throw error;
+  return data;
+};

--- a/app/sql/views/product-overview-view.sql
+++ b/app/sql/views/product-overview-view.sql
@@ -1,0 +1,19 @@
+create or replace view product_overview_view as
+select
+   product_id,
+   name,
+   tagline,
+   description,
+   how_it_works,
+   icon,
+   url,
+   stats->>'upvotes' as upvotes,
+   stats->>'views' as views,
+   stats->>'reviews' as reviews,
+   avg(product_reviews.rating) as average_rating
+from public.products
+left join public.reviews as product_reviews using (product_id)
+group by product_id;
+
+
+select * from product_overview_view;

--- a/app/supa-client.ts
+++ b/app/supa-client.ts
@@ -21,6 +21,11 @@ type Database = MergeDeep<
             SupabaseDatabase["public"]["Views"]["gpt_ideas_view"]["Row"]
           >;
         };
+        product_overview_view: {
+          Row: SetNonNullable<
+            SupabaseDatabase["public"]["Views"]["product_overview_view"]["Row"]
+          >;
+        };
       };
     };
   }

--- a/database.types.ts
+++ b/database.types.ts
@@ -329,6 +329,13 @@ export type Database = {
             foreignKeyName: "notifications_product_id_products_product_id_fk"
             columns: ["product_id"]
             isOneToOne: false
+            referencedRelation: "product_overview_view"
+            referencedColumns: ["product_id"]
+          },
+          {
+            foreignKeyName: "notifications_product_id_products_product_id_fk"
+            columns: ["product_id"]
+            isOneToOne: false
             referencedRelation: "products"
             referencedColumns: ["product_id"]
           },
@@ -513,6 +520,13 @@ export type Database = {
             foreignKeyName: "product_upvotes_product_id_products_product_id_fk"
             columns: ["product_id"]
             isOneToOne: false
+            referencedRelation: "product_overview_view"
+            referencedColumns: ["product_id"]
+          },
+          {
+            foreignKeyName: "product_upvotes_product_id_products_product_id_fk"
+            columns: ["product_id"]
+            isOneToOne: false
             referencedRelation: "products"
             referencedColumns: ["product_id"]
           },
@@ -660,6 +674,13 @@ export type Database = {
             foreignKeyName: "reviews_product_id_products_product_id_fk"
             columns: ["product_id"]
             isOneToOne: false
+            referencedRelation: "product_overview_view"
+            referencedColumns: ["product_id"]
+          },
+          {
+            foreignKeyName: "reviews_product_id_products_product_id_fk"
+            columns: ["product_id"]
+            isOneToOne: false
             referencedRelation: "products"
             referencedColumns: ["product_id"]
           },
@@ -764,6 +785,22 @@ export type Database = {
           is_claimed: boolean | null
           likes: number | null
           views: number | null
+        }
+        Relationships: []
+      }
+      product_overview_view: {
+        Row: {
+          average_rating: number | null
+          description: string | null
+          how_it_works: string | null
+          icon: string | null
+          name: string | null
+          product_id: number | null
+          reviews: string | null
+          tagline: string | null
+          upvotes: string | null
+          url: string | null
+          views: string | null
         }
         Relationships: []
       }


### PR DESCRIPTION
- product-overview-layout에 loader와 meta 함수 추가하여 제품 데이터를 서버에서 받아오도록 변경  
- 제품 이름, 태그라인, 평점, 리뷰 수, 업보트 수 등 동적 정보 표시 구현  
- product-overview에서 하드코딩된 설명을 useOutletContext로 전달받은 실제 데이터로 대체  
- supa-client에 product_overview_view 타입 추가로 타입 안정성 강화  
- URL 경로에 제품 ID를 반영하여 라우팅 동적 처리 가능하게 수정