### PR TITLE
feat: 잡 상세 페이지에 데이터 로딩 및 동적 렌더링 추가

### DIFF
--- a/app/features/jobs/pages/job-page.tsx
+++ b/app/features/jobs/pages/job-page.tsx
@@ -2,12 +2,33 @@ import { DotIcon } from "lucide-react";
 import { Badge } from "~/common/components/ui/badge";
 import { Button } from "~/common/components/ui/button";
 import type { Route } from "./+types/job-page";
+import { z } from "zod";
+import { data } from "react-router";
+import { getJobById } from "../queries";
+import { DateTime } from "luxon";
 
 export const meta: Route.MetaFunction = () => [
   { title: "Job Details | wemake" },
 ];
 
-export default function JobPage() {
+export const paramsSchema = z.object({
+  jobId: z.coerce.number(),
+});
+
+export const loader = async ({ params }: Route.LoaderArgs) => {
+  const { success, data: parsedData } = paramsSchema.safeParse(params);
+
+  if (!success)
+    throw data(
+      { error_code: "invalid params", message: "Invalid params" },
+      { status: 400 }
+    );
+
+  const job = await getJobById(parsedData.jobId);
+  return { job };
+};
+
+export default function JobPage({ loaderData }: Route.ComponentProps) {
   return (
     <div>
       <div className="bg-gradient-to-tr from-primary/80 to-primary/10 h-60 w-full rounded-lg"></div>
@@ -15,34 +36,25 @@ export default function JobPage() {
         <div className="col-span-4 space-y-10">
           <div>
             <div className="size-40 bg-white rounded-full overflow-hidden relative left-10">
-              <img
-                src="https://github.com/facebook.png"
-                className="object-cover"
-              />
+              <img src={loaderData.job.company_logo} className="object-cover" />
             </div>
-            <h1 className="text-4xl font-bold">Software Engineer</h1>
-            <h4 className="text-lg text-muted-foreground">Meta Inc.</h4>
+            <h1 className="text-4xl font-bold">{loaderData.job.position}</h1>
+            <h4 className="text-lg text-muted-foreground">
+              {loaderData.job.company_name}
+            </h4>
           </div>
-          <div className="flex gap-2">
-            <Badge variant="secondary">Full-time</Badge>
-            <Badge variant="secondary">Remote</Badge>
+          <div className="flex gap-2 capitalize">
+            <Badge variant="secondary">{loaderData.job.job_type}</Badge>
+            <Badge variant="secondary">{loaderData.job.location}</Badge>
           </div>
           <div className="space-y-2.5">
             <h4 className="text-2xl font-bold">Overview</h4>
-            <p className="text-lg">
-              This is a full-time remote position. We are looking for a Software
-              Engineer with a passion for building scalable and efficient
-              systems.
-            </p>
+            <p className="text-lg">{loaderData.job.overview}</p>
           </div>
           <div className="space-y-2.5">
             <h4 className="text-2xl font-bold">Responsibilities</h4>
             <ul className="text-lg list-disc list-inside">
-              {[
-                "Develop and maintain web applications using React, Next.js, and Tailwind CSS.",
-                "Collaborate with the design team to implement new features and improve user experience.",
-                "Optimize application performance and ensure scalability.",
-              ].map((item) => (
+              {loaderData.job.responsibilities.split(",").map((item) => (
                 <li key={item}>{item}</li>
               ))}
             </ul>
@@ -50,13 +62,7 @@ export default function JobPage() {
           <div className="space-y-2.5">
             <h4 className="text-2xl font-bold">Qualifications</h4>
             <ul className="text-lg list-disc list-inside">
-              {[
-                "Bachelor's degree in Computer Science or related field.",
-                "3+ years of experience in software development.",
-                "Strong proficiency in React, Next.js, and Tailwind CSS.",
-                "Excellent problem-solving skills and attention to detail.",
-                "Excellent communication skills and ability to work in a team.",
-              ].map((item) => (
+              {loaderData.job.qualifications.split(",").map((item) => (
                 <li key={item}>{item}</li>
               ))}
             </ul>
@@ -64,11 +70,7 @@ export default function JobPage() {
           <div className="space-y-2.5">
             <h4 className="text-2xl font-bold">Benefits</h4>
             <ul className="text-lg list-disc list-inside">
-              {[
-                "Flexible working hours and remote work options.",
-                "Competitive salary and benefits package.",
-                "Opportunity to work on cutting-edge projects and technologies.",
-              ].map((item) => (
+              {loaderData.job.benefits.split(",").map((item) => (
                 <li key={item}>{item}</li>
               ))}
             </ul>
@@ -76,30 +78,34 @@ export default function JobPage() {
           <div className="space-y-2.5">
             <h4 className="text-2xl font-bold">Skills</h4>
             <ul className="text-lg list-disc list-inside">
-              {["React", "Next.js", "Tailwind CSS", "TypeScript"].map(
-                (item) => (
-                  <li key={item}>{item}</li>
-                )
-              )}
+              {loaderData.job.skills.split(",").map((item) => (
+                <li key={item}>{item}</li>
+              ))}
             </ul>
           </div>
         </div>
         <div className="col-span-2 sticky top-20 border p-6 rounded-lg mt-32 space-y-5">
           <div className="flex flex-col">
             <span className="text-sm text-muted-foreground">Avg. Salary</span>
-            <span className="text-2xl font-medium">$100,000 - $120,000</span>
+            <span className="text-2xl font-medium">
+              {loaderData.job.salary_range}
+            </span>
           </div>
           <div className="flex flex-col">
             <span className="text-sm text-muted-foreground">Location</span>
-            <span className="text-2xl font-medium">Remote</span>
+            <span className="text-2xl font-medium capitalize">
+              {loaderData.job.location}
+            </span>
           </div>
           <div className="flex flex-col">
             <span className="text-sm text-muted-foreground">Type</span>
-            <span className="text-2xl font-medium">Full Time</span>
+            <span className="text-2xl font-medium capitalize">
+              {loaderData.job.job_type}
+            </span>
           </div>
           <div className="flex items-center">
             <span className="text-sm text-muted-foreground">
-              Posted 2 days ago
+              Posted {DateTime.fromISO(loaderData.job.created_at).toRelative()}
             </span>
             <DotIcon className="size-4" />
             <span className="text-sm text-muted-foreground">365 views</span>

--- a/app/features/jobs/queries.ts
+++ b/app/features/jobs/queries.ts
@@ -47,3 +47,14 @@ export const getJobs = async ({
   if (error) throw error;
   return data;
 };
+
+export const getJobById = async (jobId: number) => {
+  const { data, error } = await client
+    .from("jobs")
+    .select("*")
+    .eq("job_id", jobId)
+    .single();
+
+  if (error) throw error;
+  return data;
+};


### PR DESCRIPTION
- 잡 ID를 파라미터로 받아 유효성 검증 후 API에서 잡 정보를 비동기로 로드하는 loader 함수 구현  
- 서버에서 받아온 직무 정보를 컴포넌트에 전달하여 동적 렌더링 적용  
- 회사 로고, 직무명, 회사명, 근무 형태, 위치, 개요, 책임, 자격 요건, 혜택, 기술 목록을 하드코딩 대신 동적으로 표시  
- 유효하지 않은 파라미터에 대해 400 에러 반환으로 안정성 향상